### PR TITLE
[feat/daengle-5] JWT 토큰 검증 및 Payload 정보 추출 단일화

### DIFF
--- a/src/main/java/ddog/daengleserver/application/AccountService.java
+++ b/src/main/java/ddog/daengleserver/application/AccountService.java
@@ -1,4 +1,29 @@
 package ddog.daengleserver.application;
 
+import ddog.daengleserver.application.repository.AccountRepository;
+import ddog.daengleserver.domain.Account;
+import ddog.daengleserver.global.auth.config.enums.Role;
+import ddog.daengleserver.presentation.dto.response.AccountInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class AccountService {
+
+    private final AccountRepository accountRepository;
+
+    public AccountInfoDto getAccountInfo(String email, Role role) {
+        Account account = accountRepository.findAccountByEmailAndRole(email, role);
+        return account.withAccount();
+    }
+
+    @Transactional
+    public void updateNicknameById(long id, String nickname) {
+        Account account = accountRepository.findBy(id);
+        account = account.withNickname(nickname);
+        accountRepository.save(account);
+    }
+
 }

--- a/src/main/java/ddog/daengleserver/application/repository/AccountRepository.java
+++ b/src/main/java/ddog/daengleserver/application/repository/AccountRepository.java
@@ -8,4 +8,8 @@ public interface AccountRepository {
     boolean checkExistsAccountBy(String email, Role role);
 
     void save(Account account);
+
+    Account findBy(long id);
+
+    Account findAccountByEmailAndRole(String email, Role role);
 }

--- a/src/main/java/ddog/daengleserver/domain/Account.java
+++ b/src/main/java/ddog/daengleserver/domain/Account.java
@@ -2,7 +2,10 @@ package ddog.daengleserver.domain;
 
 import ddog.daengleserver.global.auth.config.enums.Provider;
 import ddog.daengleserver.global.auth.config.enums.Role;
-import lombok.*;
+import ddog.daengleserver.presentation.dto.response.AccountInfoDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
@@ -15,4 +18,21 @@ public class Account {
     private final Provider provider;
     private final Role role;
 
+    public Account withNickname(String nickname) {
+        return Account.builder()
+                .id(this.id)
+                .email(this.email)
+                .nickname(nickname)
+                .provider(this.provider)
+                .role(this.role)
+                .build();
+    }
+
+    public AccountInfoDto withAccount() {
+        return AccountInfoDto.builder()
+                .email(this.email)
+                .nickname(this.nickname)
+                .provider(this.provider)
+                .build();
+    }
 }

--- a/src/main/java/ddog/daengleserver/global/auth/application/OAuthService.java
+++ b/src/main/java/ddog/daengleserver/global/auth/application/OAuthService.java
@@ -3,11 +3,11 @@ package ddog.daengleserver.global.auth.application;
 import ddog.daengleserver.application.repository.AccountRepository;
 import ddog.daengleserver.domain.Account;
 import ddog.daengleserver.global.auth.config.enums.Provider;
+import ddog.daengleserver.global.auth.config.enums.Role;
 import ddog.daengleserver.global.auth.config.jwt.JwtTokenProvider;
 import ddog.daengleserver.global.auth.dto.RefreshTokenDto;
 import ddog.daengleserver.global.auth.dto.TokenAccountInfoDto;
 import ddog.daengleserver.global.auth.dto.TokenInfoDto;
-import ddog.daengleserver.global.auth.config.enums.Role;
 import ddog.daengleserver.global.auth.exception.AuthException;
 import ddog.daengleserver.global.auth.exception.enums.AuthExceptionType;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +31,15 @@ public class OAuthService {
     private final AccountRepository accountRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
+    public static Role fromString(String roleString) {
+        for (Role role : Role.values()) {
+            if (role.name().equalsIgnoreCase(roleString)) {
+                return role;
+            }
+        }
+        throw new AuthException(AuthExceptionType.UNAVAILABLE_ROLE);
+    }
+
     public TokenInfoDto kakaoOAuthLogin(String kakaoAccessToken, String loginType) {
         /* kakaoAccessToken 정보를 가지고 유저의 닉네임, 이메일 정보를 가져온다. */
         HashMap<String, Object> kakaoUserInfo = kakaoSocialService.getKakaoUserInfo(kakaoAccessToken);
@@ -39,12 +48,11 @@ public class OAuthService {
 
         Role role = fromString(loginType);
         if (!accountRepository.checkExistsAccountBy(email, role)) {
-            /* 추후에 만약 회원이 없다면 회원가입 페이지로 보낼 수 있도록 로직 변경하며,
-             * saveAccount() 는 회원가입에서 등록했을 때 동작하도록 로직 변경해줘야 함. */
+            /* 만약 회원이 아니라면 회원가입 페이지로 보낼 수 있도록 로직 추가해줘야 함. */
             saveAccount(kakaoUserInfo, email, role);
         }
 
-        return jwtTokenProvider.generateToken(getAuthentication(email,ROLE + loginType, loginType), role);
+        return jwtTokenProvider.generateToken(getAuthentication(email, ROLE + loginType), role);
     }
 
     private void saveAccount(HashMap<String, Object> kakaoUserInfo, String email, Role role) {
@@ -58,12 +66,12 @@ public class OAuthService {
         accountRepository.save(account);
     }
 
-    private Authentication getAuthentication(String email, String role, String loginType) {
+    private Authentication getAuthentication(String email, String role) {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority(role));
 
         Authentication authentication
-                = new UsernamePasswordAuthenticationToken(email + "," + loginType, null, authorities);
+                = new UsernamePasswordAuthenticationToken(email, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
         return authentication;
     }
@@ -78,15 +86,6 @@ public class OAuthService {
         TokenAccountInfoDto.TokenInfo tokenInfo = jwtTokenProvider.extractTokenInfoFromJwt(refreshToken);
         String email = tokenInfo.getEmail();
 
-        return jwtTokenProvider.generateToken(getAuthentication(email,ROLE + refreshTokenDto.getLoginType(), refreshTokenDto.getLoginType()), Role.CUSTOMER);
-    }
-
-    public static Role fromString(String roleString) {
-        for (Role role : Role.values()) {
-            if (role.name().equalsIgnoreCase(roleString)) {
-                return role;
-            }
-        }
-        throw new AuthException(AuthExceptionType.UNAVAILABLE_ROLE);
+        return jwtTokenProvider.generateToken(getAuthentication(email, ROLE + refreshTokenDto.getLoginType()), Role.CUSTOMER);
     }
 }

--- a/src/main/java/ddog/daengleserver/global/auth/application/OAuthService.java
+++ b/src/main/java/ddog/daengleserver/global/auth/application/OAuthService.java
@@ -10,6 +10,7 @@ import ddog.daengleserver.global.auth.dto.TokenAccountInfoDto;
 import ddog.daengleserver.global.auth.dto.TokenInfoDto;
 import ddog.daengleserver.global.auth.exception.AuthException;
 import ddog.daengleserver.global.auth.exception.enums.AuthExceptionType;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -40,7 +41,7 @@ public class OAuthService {
         throw new AuthException(AuthExceptionType.UNAVAILABLE_ROLE);
     }
 
-    public TokenInfoDto kakaoOAuthLogin(String kakaoAccessToken, String loginType) {
+    public TokenInfoDto kakaoOAuthLogin(String kakaoAccessToken, String loginType, HttpServletResponse response) {
         /* kakaoAccessToken 정보를 가지고 유저의 닉네임, 이메일 정보를 가져온다. */
         HashMap<String, Object> kakaoUserInfo = kakaoSocialService.getKakaoUserInfo(kakaoAccessToken);
 
@@ -52,7 +53,7 @@ public class OAuthService {
             saveAccount(kakaoUserInfo, email, role);
         }
 
-        return jwtTokenProvider.generateToken(getAuthentication(email, ROLE + loginType), role);
+        return jwtTokenProvider.generateToken(getAuthentication(email, ROLE + loginType), role, response);
     }
 
     private void saveAccount(HashMap<String, Object> kakaoUserInfo, String email, Role role) {
@@ -76,7 +77,7 @@ public class OAuthService {
         return authentication;
     }
 
-    public TokenInfoDto reGenerateAccessToken(RefreshTokenDto refreshTokenDto) {
+    public TokenInfoDto reGenerateAccessToken(RefreshTokenDto refreshTokenDto, HttpServletResponse response) {
         String refreshToken = refreshTokenDto.getRefreshToken();
         if (!jwtTokenProvider.validateToken(refreshToken.substring(7).trim())) {
             /* 추후에 INVALID_TOKEN 으로 변경 예정 */
@@ -86,6 +87,6 @@ public class OAuthService {
         TokenAccountInfoDto.TokenInfo tokenInfo = jwtTokenProvider.extractTokenInfoFromJwt(refreshToken);
         String email = tokenInfo.getEmail();
 
-        return jwtTokenProvider.generateToken(getAuthentication(email, ROLE + refreshTokenDto.getLoginType()), Role.CUSTOMER);
+        return jwtTokenProvider.generateToken(getAuthentication(email, ROLE + refreshTokenDto.getLoginType()), Role.CUSTOMER, response);
     }
 }

--- a/src/main/java/ddog/daengleserver/global/auth/config/SecurityConfig.java
+++ b/src/main/java/ddog/daengleserver/global/auth/config/SecurityConfig.java
@@ -52,8 +52,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/**").permitAll()
-                        .requestMatchers("/api/oauth/kakao/**").permitAll()    // Kakao 소셜 로그인을 위한 URL 허용
+                        .requestMatchers("/api/login", "/api/get-info").permitAll()
+                        .requestMatchers("/api/oauth/**").permitAll()  // Kakao 소셜 로그인을 위한 URL 허용
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .requestMatchers("/customer").hasRole("CUSTOMER")
                         .requestMatchers("/groomer").hasRole("GROOMER"))

--- a/src/main/java/ddog/daengleserver/global/auth/config/SecurityConfig.java
+++ b/src/main/java/ddog/daengleserver/global/auth/config/SecurityConfig.java
@@ -52,11 +52,11 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/api/login", "/api/get-info").permitAll()
+                        .requestMatchers("/**").permitAll() // 임시로 모든 API 에 대해 통과
                         .requestMatchers("/api/oauth/**").permitAll()  // Kakao 소셜 로그인을 위한 URL 허용
-                        .requestMatchers("/admin").hasRole("ADMIN")
-                        .requestMatchers("/customer").hasRole("CUSTOMER")
-                        .requestMatchers("/groomer").hasRole("GROOMER"))
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/customer/**").hasRole("CUSTOMER")
+                        .requestMatchers("/groomer/**").hasRole("GROOMER"))
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/ddog/daengleserver/global/auth/config/WebConfig.java
+++ b/src/main/java/ddog/daengleserver/global/auth/config/WebConfig.java
@@ -1,0 +1,21 @@
+package ddog.daengleserver.global.auth.config;
+
+import ddog.daengleserver.global.auth.resolver.PayloadArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final PayloadArgumentResolver payloadArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(payloadArgumentResolver);
+    }
+}

--- a/src/main/java/ddog/daengleserver/global/auth/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/ddog/daengleserver/global/auth/config/jwt/JwtAuthenticationFilter.java
@@ -22,18 +22,20 @@ import java.util.List;
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final List<String> excludeUrls = List.of("/api/login"); // 필터 제외 URL
+    /* 필터 제외 URL 리스트 */
+    private final List<String> excludeUrls = List.of(
+            "/api/oauth/kakao", "/api/oauth/refresh-token"
+    );
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        String token = resolveToken((HttpServletRequest) request);
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-
         if (excludeUrls.contains(httpServletRequest.getRequestURI())) {
             chain.doFilter(request, response);
             return;
         }
 
+        String token = resolveToken((HttpServletRequest) request);
         try {
             if (jwtTokenProvider.validateToken(token)) {
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);

--- a/src/main/java/ddog/daengleserver/global/auth/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/ddog/daengleserver/global/auth/config/jwt/JwtAuthenticationFilter.java
@@ -8,36 +8,46 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
+import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final List<String> excludeUrls = List.of("/api/login"); // 필터 제외 URL
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String token = resolveToken((HttpServletRequest) request);
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        if (excludeUrls.contains(httpServletRequest.getRequestURI())) {
+            chain.doFilter(request, response);
+            return;
+        }
 
         try {
-            if (token != null && jwtTokenProvider.validateToken(token)) {
+            if (jwtTokenProvider.validateToken(token)) {
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (ExpiredJwtException e) {
             /* 추후에 EXPIRED_TOKEN 으로 변경 예정 */
-            throw new RuntimeException();
+            throw new RuntimeException(e);
         } catch (UnsupportedJwtException e) {
             /* 추후에 UNSUPPORTED_TOKEN 으로 변경 예정 */
-            throw new RuntimeException();
+            throw new RuntimeException(e);
         } catch (Exception e) {
             /* 추후에 UNKNOWN_ERROR 으로 변경 예정 */
-            throw new RuntimeException();
+            throw new RuntimeException(e);
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/ddog/daengleserver/global/auth/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/ddog/daengleserver/global/auth/config/jwt/JwtTokenProvider.java
@@ -3,7 +3,6 @@ package ddog.daengleserver.global.auth.config.jwt;
 import ddog.daengleserver.application.repository.AccountRepository;
 import ddog.daengleserver.global.auth.dto.TokenAccountInfoDto;
 import ddog.daengleserver.global.auth.dto.TokenInfoDto;
-import ddog.daengleserver.global.auth.config.enums.Provider;
 import ddog.daengleserver.global.auth.config.enums.Role;
 import ddog.daengleserver.implementation.AccountException;
 import ddog.daengleserver.implementation.enums.AccountExceptionType;
@@ -91,10 +90,10 @@ public class JwtTokenProvider {
             throw new AccountException(AccountExceptionType.ACCOUNT_EXCEPTION_TYPE);
         }
 
-        return new UsernamePasswordAuthenticationToken(accessToken, authorities);
+        return new UsernamePasswordAuthenticationToken(accessToken, null, authorities);
     }
 
-    private Claims parseClaims(String accessToken) {
+    public Claims parseClaims(String accessToken) {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(key)

--- a/src/main/java/ddog/daengleserver/global/auth/dto/PayloadDto.java
+++ b/src/main/java/ddog/daengleserver/global/auth/dto/PayloadDto.java
@@ -1,0 +1,14 @@
+package ddog.daengleserver.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PayloadDto {
+
+    private String email;
+    private String role;
+}

--- a/src/main/java/ddog/daengleserver/global/auth/dto/PayloadDto.java
+++ b/src/main/java/ddog/daengleserver/global/auth/dto/PayloadDto.java
@@ -1,5 +1,6 @@
 package ddog.daengleserver.global.auth.dto;
 
+import ddog.daengleserver.global.auth.config.enums.Role;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PayloadDto {
-
     private String email;
-    private String role;
+    private Role role;
 }

--- a/src/main/java/ddog/daengleserver/global/auth/dto/TokenAccountInfoDto.java
+++ b/src/main/java/ddog/daengleserver/global/auth/dto/TokenAccountInfoDto.java
@@ -28,6 +28,6 @@ public class TokenAccountInfoDto {
     @Builder
     public static class TokenInfo {
         private String email;
-        private String provider;
+        private String role;
     }
 }

--- a/src/main/java/ddog/daengleserver/global/auth/dto/TokenInfoDto.java
+++ b/src/main/java/ddog/daengleserver/global/auth/dto/TokenInfoDto.java
@@ -10,6 +10,5 @@ public class TokenInfoDto {
 
     private final String grantType;
     private final String accessToken;
-    private final String refreshToken;
     private final Role role;
 }

--- a/src/main/java/ddog/daengleserver/global/auth/presentation/OAuthController.java
+++ b/src/main/java/ddog/daengleserver/global/auth/presentation/OAuthController.java
@@ -5,6 +5,7 @@ import ddog.daengleserver.global.auth.dto.KakaoAccessTokenDto;
 import ddog.daengleserver.global.auth.dto.RefreshTokenDto;
 import ddog.daengleserver.global.auth.dto.TokenInfoDto;
 import ddog.daengleserver.global.common.CommonResponseEntity;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,13 +24,12 @@ public class OAuthController {
     private final OAuthService oAuthService;
 
     @PostMapping("/kakao")
-    public CommonResponseEntity<TokenInfoDto> kakaoLogin(@RequestBody KakaoAccessTokenDto kakaoAccessTokenDto) {
-        return success(oAuthService.kakaoOAuthLogin(kakaoAccessTokenDto.getKakaoAccessToken(), kakaoAccessTokenDto.getLoginType()));
+    public CommonResponseEntity<TokenInfoDto> kakaoLogin(@RequestBody KakaoAccessTokenDto kakaoAccessTokenDto, HttpServletResponse response) {
+        return success(oAuthService.kakaoOAuthLogin(kakaoAccessTokenDto.getKakaoAccessToken(), kakaoAccessTokenDto.getLoginType(), response));
     }
 
     @PostMapping("/refresh-token")
-    public CommonResponseEntity<TokenInfoDto> reGenerateAccessToken(@RequestBody RefreshTokenDto refreshTokenDto) {
-        oAuthService.reGenerateAccessToken(refreshTokenDto);
-        return success(oAuthService.reGenerateAccessToken(refreshTokenDto));
+    public CommonResponseEntity<TokenInfoDto> reGenerateAccessToken(@RequestBody RefreshTokenDto refreshTokenDto, HttpServletResponse response) {
+        return success(oAuthService.reGenerateAccessToken(refreshTokenDto, response));
     }
 }

--- a/src/main/java/ddog/daengleserver/global/auth/resolver/PayloadArgumentResolver.java
+++ b/src/main/java/ddog/daengleserver/global/auth/resolver/PayloadArgumentResolver.java
@@ -1,0 +1,51 @@
+package ddog.daengleserver.global.auth.resolver;
+
+import ddog.daengleserver.global.auth.config.jwt.JwtTokenProvider;
+import ddog.daengleserver.global.auth.dto.PayloadDto;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class PayloadArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // 컨트롤러 메서드 매개변수가 Payload 타입인 경우 처리
+        return parameter.getParameterType().equals(PayloadDto.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = resolveToken(request);
+
+        if (jwtTokenProvider.validateToken(token)) {
+            Claims claims = jwtTokenProvider.parseClaims(token);
+            String email = claims.getSubject();
+            String role = claims.get("auth", String.class);
+
+            return new PayloadDto(email, role);
+        }
+
+        return null;
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/ddog/daengleserver/implementation/enums/AccountExceptionType.java
+++ b/src/main/java/ddog/daengleserver/implementation/enums/AccountExceptionType.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum AccountExceptionType {
-    ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, "404"),;
+    ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, "404"),
+    NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, "404"),;
 
     private HttpStatus status;
     private String code;

--- a/src/main/java/ddog/daengleserver/infrastructure/AccountJpaRepository.java
+++ b/src/main/java/ddog/daengleserver/infrastructure/AccountJpaRepository.java
@@ -1,5 +1,6 @@
 package ddog.daengleserver.infrastructure;
 
+import ddog.daengleserver.domain.Account;
 import ddog.daengleserver.global.auth.config.enums.Provider;
 import ddog.daengleserver.global.auth.config.enums.Role;
 import ddog.daengleserver.infrastructure.jpa.AccountJpaEntity;
@@ -15,4 +16,5 @@ public interface AccountJpaRepository extends JpaRepository<AccountJpaEntity, Lo
 
     Optional<AccountJpaEntity> findByEmailAndProvider(String email, Provider provider);
 
+    Optional<AccountJpaEntity> findByEmailAndRole(String email, Role role);
 }

--- a/src/main/java/ddog/daengleserver/infrastructure/AccountRepositoryImpl.java
+++ b/src/main/java/ddog/daengleserver/infrastructure/AccountRepositoryImpl.java
@@ -3,9 +3,13 @@ package ddog.daengleserver.infrastructure;
 import ddog.daengleserver.application.repository.AccountRepository;
 import ddog.daengleserver.domain.Account;
 import ddog.daengleserver.global.auth.config.enums.Role;
+import ddog.daengleserver.implementation.AccountException;
+import ddog.daengleserver.implementation.enums.AccountExceptionType;
 import ddog.daengleserver.infrastructure.jpa.AccountJpaEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,5 +25,20 @@ public class AccountRepositoryImpl implements AccountRepository {
     @Override
     public void save(Account account) {
         accountJpaRepository.save(AccountJpaEntity.from(account));
+    }
+
+    @Override
+    public Account findBy(long id) {
+        return accountJpaRepository.findById(id)
+                .orElseThrow(() -> new AccountException(AccountExceptionType.NOT_FOUND_ACCOUNT))
+                .toModel();
+    }
+
+    @Override
+    public Account findAccountByEmailAndRole(String email, Role role) {
+        Optional<AccountJpaEntity> byEmailAndRole = accountJpaRepository.findByEmailAndRole(email, role);
+        AccountJpaEntity accountJpaEntity = byEmailAndRole.orElseThrow(() -> new AccountException(AccountExceptionType.NOT_FOUND_ACCOUNT));
+        Account model = accountJpaEntity.toModel();
+        return model;
     }
 }

--- a/src/main/java/ddog/daengleserver/infrastructure/jpa/AccountJpaEntity.java
+++ b/src/main/java/ddog/daengleserver/infrastructure/jpa/AccountJpaEntity.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Entity(name = "Customer")
+@Entity(name = "Account")
 public class AccountJpaEntity {
 
     @Id

--- a/src/main/java/ddog/daengleserver/presentation/AccountController.java
+++ b/src/main/java/ddog/daengleserver/presentation/AccountController.java
@@ -1,10 +1,31 @@
 package ddog.daengleserver.presentation;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import ddog.daengleserver.application.AccountService;
+import ddog.daengleserver.global.auth.dto.PayloadDto;
+import ddog.daengleserver.global.common.CommonResponseEntity;
+import ddog.daengleserver.presentation.dto.request.UpdateNicknameDto;
+import ddog.daengleserver.presentation.dto.response.AccountInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import static ddog.daengleserver.global.common.CommonResponseEntity.success;
+import static ddog.daengleserver.presentation.enums.AccountControllerResp.UPDATE_COMPLETED;
 
 @RestController
 @RequestMapping("/api")
+@RequiredArgsConstructor
 public class AccountController {
 
+    private final AccountService accountService;
+
+    @GetMapping("/account-info")
+    public CommonResponseEntity<AccountInfoDto> getAccountInfo(PayloadDto payloadDto) {
+        return success(accountService.getAccountInfo(payloadDto.getEmail(), payloadDto.getRole()));
+    }
+
+    @PostMapping("/nickname")
+    public CommonResponseEntity<String> updateNickname(@RequestBody UpdateNicknameDto updateNicknameDto) {
+        accountService.updateNicknameById(updateNicknameDto.getId(), updateNicknameDto.getNickname());
+        return success(UPDATE_COMPLETED.getMessage());
+    }
 }

--- a/src/main/java/ddog/daengleserver/presentation/AccountController.java
+++ b/src/main/java/ddog/daengleserver/presentation/AccountController.java
@@ -1,29 +1,10 @@
 package ddog.daengleserver.presentation;
 
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api")
 public class AccountController {
-
-    @GetMapping("/login")
-    public String login() {
-        return "SUCCESS";
-    }
-
-    @GetMapping("/admin")
-    public String admin() {
-        return "ADMIN";
-    }
-
-    @GetMapping("/get-info")
-    public String getInfo() {
-        Object credentials = SecurityContextHolder.getContext().getAuthentication().getCredentials();
-        System.out.println(credentials);
-        return "SUCCESS";
-    }
 
 }

--- a/src/main/java/ddog/daengleserver/presentation/AccountController.java
+++ b/src/main/java/ddog/daengleserver/presentation/AccountController.java
@@ -1,4 +1,29 @@
 package ddog.daengleserver.presentation;
 
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
 public class AccountController {
+
+    @GetMapping("/login")
+    public String login() {
+        return "SUCCESS";
+    }
+
+    @GetMapping("/admin")
+    public String admin() {
+        return "ADMIN";
+    }
+
+    @GetMapping("/get-info")
+    public String getInfo() {
+        Object credentials = SecurityContextHolder.getContext().getAuthentication().getCredentials();
+        System.out.println(credentials);
+        return "SUCCESS";
+    }
+
 }

--- a/src/main/java/ddog/daengleserver/presentation/dto/request/UpdateNicknameDto.java
+++ b/src/main/java/ddog/daengleserver/presentation/dto/request/UpdateNicknameDto.java
@@ -1,0 +1,9 @@
+package ddog.daengleserver.presentation.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameDto {
+    private Long id;
+    private String nickname;
+}

--- a/src/main/java/ddog/daengleserver/presentation/dto/response/AccountInfoDto.java
+++ b/src/main/java/ddog/daengleserver/presentation/dto/response/AccountInfoDto.java
@@ -1,0 +1,13 @@
+package ddog.daengleserver.presentation.dto.response;
+
+import ddog.daengleserver.global.auth.config.enums.Provider;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AccountInfoDto {
+    private String email;
+    private String nickname;
+    private Provider provider;
+}

--- a/src/main/java/ddog/daengleserver/presentation/enums/AccountControllerResp.java
+++ b/src/main/java/ddog/daengleserver/presentation/enums/AccountControllerResp.java
@@ -1,0 +1,12 @@
+package ddog.daengleserver.presentation.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AccountControllerResp {
+    UPDATE_COMPLETED("업데이트 완료");
+
+    private String message;
+}


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : X
    - [Notion-API] : X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - JWT 토큰 검증 및 Payload 데이터 (email, role) 정보를 필터단에서 처리
    - Payload 데이터를 `ArgumentResolver` 를 통해 `PayloadDto` 에 저장

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 발생할 수 있는 예외에 대한 상세한 처리 필요

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
