### PR TITLE
[feat/daengle-6] Account 도메인 컨트롤러 <-> Service 의존성 역전

### DIFF
--- a/src/main/java/ddog/daengleserver/application/AccountService.java
+++ b/src/main/java/ddog/daengleserver/application/AccountService.java
@@ -4,13 +4,14 @@ import ddog.daengleserver.application.repository.AccountRepository;
 import ddog.daengleserver.domain.Account;
 import ddog.daengleserver.global.auth.config.enums.Role;
 import ddog.daengleserver.presentation.dto.response.AccountInfoDto;
+import ddog.daengleserver.presentation.usecase.AccountUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class AccountService {
+public class AccountService implements AccountUseCase {
 
     private final AccountRepository accountRepository;
 

--- a/src/main/java/ddog/daengleserver/presentation/AccountController.java
+++ b/src/main/java/ddog/daengleserver/presentation/AccountController.java
@@ -1,10 +1,10 @@
 package ddog.daengleserver.presentation;
 
-import ddog.daengleserver.application.AccountService;
 import ddog.daengleserver.global.auth.dto.PayloadDto;
 import ddog.daengleserver.global.common.CommonResponseEntity;
 import ddog.daengleserver.presentation.dto.request.UpdateNicknameDto;
 import ddog.daengleserver.presentation.dto.response.AccountInfoDto;
+import ddog.daengleserver.presentation.usecase.AccountUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +16,7 @@ import static ddog.daengleserver.presentation.enums.AccountControllerResp.UPDATE
 @RequiredArgsConstructor
 public class AccountController {
 
-    private final AccountService accountService;
+    private final AccountUseCase accountService;
 
     @GetMapping("/account-info")
     public CommonResponseEntity<AccountInfoDto> getAccountInfo(PayloadDto payloadDto) {

--- a/src/main/java/ddog/daengleserver/presentation/usecase/AccountUseCase.java
+++ b/src/main/java/ddog/daengleserver/presentation/usecase/AccountUseCase.java
@@ -1,0 +1,11 @@
+package ddog.daengleserver.presentation.usecase;
+
+import ddog.daengleserver.global.auth.config.enums.Role;
+import ddog.daengleserver.presentation.dto.response.AccountInfoDto;
+
+public interface AccountUseCase {
+
+    AccountInfoDto getAccountInfo(String email, Role role);
+
+    void updateNicknameById(long id, String nickname);
+}


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : x
    - [Notion-API] : x

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - Service 추상 계층 구현
    - 컨트롤러 <-> Service DIP 원칙 적용

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
