### PR TITLE
[refactoring/daengle-16] Order 주문 데이터 영속 방식 변경

### DIFF
--- a/src/main/java/ddog/daengleserver/application/OrderService.java
+++ b/src/main/java/ddog/daengleserver/application/OrderService.java
@@ -20,10 +20,10 @@ public class OrderService implements OrderUseCase {
 
     @Transactional
     public PostOrderResp processOrder(Long accountId, PostOrderReq postOrderReq) {
-        Payment payment = Payment.createTemporaryHistoryBy(postOrderReq);
-        paymentRepository.save(payment);
+        Payment paymentToSave = Payment.createTemporaryHistoryBy(postOrderReq);
+        Payment SavedPayment = paymentRepository.save(paymentToSave);
 
-        Order order = Order.createBy(accountId, postOrderReq, payment);
+        Order order = Order.createBy(accountId, postOrderReq, SavedPayment);
         orderRepository.save(order);
 
         return PostOrderResp.builder()

--- a/src/main/java/ddog/daengleserver/application/repository/PaymentRepository.java
+++ b/src/main/java/ddog/daengleserver/application/repository/PaymentRepository.java
@@ -3,5 +3,5 @@ package ddog.daengleserver.application.repository;
 import ddog.daengleserver.domain.Payment;
 
 public interface PaymentRepository {
-    void save(Payment payment);
+    Payment save(Payment payment);
 }

--- a/src/main/java/ddog/daengleserver/application/repository/PetRepository.java
+++ b/src/main/java/ddog/daengleserver/application/repository/PetRepository.java
@@ -5,6 +5,5 @@ import ddog.daengleserver.domain.Pet;
 import java.util.List;
 
 public interface PetRepository {
-
     List<Pet> findPetsById(Long accountId);
 }

--- a/src/main/java/ddog/daengleserver/domain/Payment.java
+++ b/src/main/java/ddog/daengleserver/domain/Payment.java
@@ -30,10 +30,6 @@ public class Payment {
                 .build();
     }
 
-    public void updatePaymentId(Long paymentId) {
-        this.paymentId = paymentId;
-    }
-
     public void cancel() {
         this.status = PaymentStatus.CANCEL;
     }

--- a/src/main/java/ddog/daengleserver/infrastructure/PaymentRepositoryImpl.java
+++ b/src/main/java/ddog/daengleserver/infrastructure/PaymentRepositoryImpl.java
@@ -13,8 +13,8 @@ import org.springframework.stereotype.Repository;
         private final PaymentJpaRepository paymentJpaRepository;
 
         @Override
-        public void save(Payment payment) {
+        public Payment save(Payment payment) {
             PaymentJpaEntity paymentJpaEntity = paymentJpaRepository.save(PaymentJpaEntity.fromModel(payment));
-            payment.updatePaymentId(paymentJpaEntity.getPaymentId());  //TODO Setter를 없애는 방향으로 리펙터링 필요
+            return paymentJpaEntity.toModel();
         }
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    -  X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 기존 Order 엔티티 객체를 영속할 때, 연관관계에 있는 Payment 엔티티 객체의 PK값을 설정하기 위해 Payment pojo객체에 id값을 Set하는 메스드를 만들어서 해결했었습니다. 로직의 예측가능성을 향상하고자 이 Setter를 없앴습니다.
    - Repository가 Payment 엔티티를 영속하고 반환까지 하게 한 뒤, 이 반환된 Payment 엔티티(id값이 존해) Order 멤버필드로 주입해서 영속합니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
