### PR TITLE
[refactoring/daengle-17] 결제 관련 예외처리 방식 변경 + 결제 검증 로직 리펙터링

### DIFF
--- a/src/main/java/ddog/daengleserver/application/PaymentService.java
+++ b/src/main/java/ddog/daengleserver/application/PaymentService.java
@@ -7,23 +7,26 @@ import ddog.daengleserver.application.repository.OrderRepository;
 import ddog.daengleserver.application.repository.PaymentRepository;
 import ddog.daengleserver.domain.Order;
 import ddog.daengleserver.domain.Payment;
+import ddog.daengleserver.domain.enums.OrderExceptionType;
 import ddog.daengleserver.domain.enums.PaymentExceptionType;
+import ddog.daengleserver.domain.exception.OrderException;
 import ddog.daengleserver.domain.exception.PaymentException;
 import ddog.daengleserver.presentation.dto.request.PaymentCallbackReq;
 import ddog.daengleserver.presentation.dto.response.PaymentCallbackResp;
 import ddog.daengleserver.presentation.usecase.PaymentUseCase;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentService implements PaymentUseCase {
 
-    public static final String PAYMENT_SUCCESS_STATUS = "paid";
     private final IamportClient iamportClient;
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
@@ -31,27 +34,27 @@ public class PaymentService implements PaymentUseCase {
     @Override
     @Transactional
     public PaymentCallbackResp validationPayment(PaymentCallbackReq paymentCallbackReq) {
-        Order order = orderRepository.findBy(paymentCallbackReq.getOrderUid());
+        Order order = orderRepository.findBy(paymentCallbackReq.getOrderUid()).orElseThrow(() -> new OrderException(OrderExceptionType.ORDER_NOT_FOUNDED));
         Payment payment = order.getPayment();
 
         try {
             com.siot.IamportRestClient.response.Payment iamportResp =
                     iamportClient.paymentByImpUid(paymentCallbackReq.getPaymentUid()).getResponse();
             String paymentStatus = iamportResp.getStatus();
+            long paymentAmount = iamportResp.getAmount().longValue();
 
-            //결제 완료 처리 확인       TODO 도메인 객체에 역할 위임
-            if(paymentStatus != PAYMENT_SUCCESS_STATUS) {
+            //결제 완료 검증
+            if(payment.checkIncompleteBy(paymentStatus)) {
                 payment.cancel();
-                paymentRepository.save(order.getPayment());
+                paymentRepository.save(payment);
 
                 throw new PaymentException(PaymentExceptionType.PAYMENT_PG_INCOMPLETE);
             }
 
-            //결제 금액 검증      TODO 도메인 객체에 역할 위임
-            Long paymentAmount = iamportResp.getAmount().longValue();
-            if(paymentAmount != payment.getPrice()) {
+            //결제 금액 검증
+            if(payment.checkInValidationBy(paymentAmount)) {
                 payment.cancel();
-                paymentRepository.save(order.getPayment());
+                paymentRepository.save(payment);
                 iamportClient.cancelPaymentByImpUid(new CancelData(iamportResp.getImpUid(), true, new BigDecimal(paymentAmount)));
 
                 throw new PaymentException(PaymentExceptionType.PAYMENT_PG_AMOUNT_MISMATCH);

--- a/src/main/java/ddog/daengleserver/application/repository/OrderRepository.java
+++ b/src/main/java/ddog/daengleserver/application/repository/OrderRepository.java
@@ -2,8 +2,10 @@ package ddog.daengleserver.application.repository;
 
 import ddog.daengleserver.domain.Order;
 
+import java.util.Optional;
+
 public interface OrderRepository {
     void save(Order order);
-    Order findBy(String orderUid);
+    Optional<Order> findBy(String orderUid);
     void delete(Order order);
 }

--- a/src/main/java/ddog/daengleserver/domain/Payment.java
+++ b/src/main/java/ddog/daengleserver/domain/Payment.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -21,6 +24,8 @@ public class Payment {
 
     private PaymentRepository paymentRepository;
 
+    public static final String PAYMENT_SUCCESS_STATUS = "paid";
+
     public static Payment createTemporaryHistoryBy(PostOrderReq postOrderReq) {
         return Payment.builder()
                 .paymentId(null)
@@ -30,12 +35,25 @@ public class Payment {
                 .build();
     }
 
-    public void cancel() {
-        this.status = PaymentStatus.CANCEL;
+    //결제 완료 확인
+    public boolean checkIncompleteBy(String paymentStatus) {
+        if(paymentStatus != PAYMENT_SUCCESS_STATUS) {
+            return true;
+        }
+        return false;
+    }
+
+    //결제 금액 유효성 검증
+    public boolean checkInValidationBy(Long paymentAmount) {
+        return !Objects.equals(this.price, paymentAmount);
     }
 
     public void validationSuccess(String impUid) {
         this.paymentUid = impUid;
         this.status = PaymentStatus.COMPLETED;
+    }
+
+    public void cancel() {
+        this.status = PaymentStatus.CANCEL;
     }
 }

--- a/src/main/java/ddog/daengleserver/infrastructure/OrderRepositoryImpl.java
+++ b/src/main/java/ddog/daengleserver/infrastructure/OrderRepositoryImpl.java
@@ -8,6 +8,8 @@ import ddog.daengleserver.infrastructure.po.OrderJpaEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class OrderRepositoryImpl implements OrderRepository {
@@ -20,8 +22,8 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public Order findBy(String orderUid) {
-        return orderJpaRepository.findByOrderUid(orderUid).orElseThrow(() -> new OrderException(OrderExceptionType.ORDER_NOT_FOUNDED)).toModel();
+    public Optional<Order> findBy(String orderUid) {
+        return orderJpaRepository.findByOrderUid(orderUid).map(OrderJpaEntity::toModel);
     }
 
     @Override

--- a/src/main/java/ddog/daengleserver/presentation/dto/response/PaymentCallbackResp.java
+++ b/src/main/java/ddog/daengleserver/presentation/dto/response/PaymentCallbackResp.java
@@ -1,7 +1,9 @@
 package ddog.daengleserver.presentation.dto.response;
 
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 @Builder
 public class PaymentCallbackResp {
     private Long userId;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - 도서 "자바/스프링 개발자를 위한 실용주의 프로그래밍"

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - Service객체의 validationPayment가 트랙잭션 스크립트처럼 작성되어 있던 것을 객체지향적인 코드로 리펙터링했습니다.
    - 유효성 검사 (결제 미완료, 결제 금액 일치 확인)를 이제 서비스단에서 진행하지 않고 도메인 엔티티가 내부적으로 수행 한뒤 결과만 전달합니다.
    - 예외처리하는 곳이 기존 컨트롤러에서 서비스단으로 변경되었습니다. 레포지토리는 옵셔널로 반환하고 서비스에서 null에 따라 예외를 던질지 결정합니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
