### PR TITLE
[refactoring/daengle-34] 사용자 등록 API 유효성 검사 로직 구현 및 예외 헨들링

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/account/Account.java
+++ b/daengle-domain/src/main/java/ddog/domain/account/Account.java
@@ -31,4 +31,27 @@ public class Account {
                 .build();
     }
 
+    public static void validateUsername(String username) {
+        if (username == null || username.length() < 2 || username.length() > 10) {
+            throw new IllegalArgumentException("Invalid username: must be 2-10 characters.");
+        }
+    }
+
+    public static void validatePhoneNumber(String phoneNumber) {
+        if (phoneNumber == null || !phoneNumber.matches("^010-\\d{4}-\\d{4}$")) {
+            throw new IllegalArgumentException("Invalid phone number: must follow format 010-0000-0000.");
+        }
+    }
+
+    public static void validateNickname(String nickname) {
+        if (nickname == null || nickname.length() < 2 || nickname.length() > 10) {
+            throw new IllegalArgumentException("Invalid nickname: must be 2-10 characters.");
+        }
+    }
+
+    public static void validateAddress(String address) {
+        if (address == null || !address.matches("^\\S+시 \\S+구 \\S+동$")) {
+            throw new IllegalArgumentException("Invalid address: must follow format '00시 00구 00동'.");
+        }
+    }/**/
 }

--- a/daengle-domain/src/main/java/ddog/domain/pet/Pet.java
+++ b/daengle-domain/src/main/java/ddog/domain/pet/Pet.java
@@ -28,4 +28,34 @@ public class Pet {
     private List<Part> dislikeParts;
     private List<SignificantTag> significantTags;
 
+    public static void validatePetName(String petName) {
+        if (petName == null || petName.length() < 2 || petName.length() > 10) {
+            throw new IllegalArgumentException("Invalid pet name: must be 2-10 characters.");
+        }
+    }
+
+    public static void validatePetBirth(int petBirth) {
+        int currentYear = java.time.Year.now().getValue();
+        if (petBirth < currentYear - 30 || petBirth > currentYear) {
+            throw new IllegalArgumentException("Invalid pet birth year: must be within last 30 years.");
+        }
+    }
+
+    public static void validatePetGender(Gender petGender) {
+        if (petGender == null) {
+            throw new IllegalArgumentException("Invalid pet gender: must be MALE or FEMALE.");
+        }
+    }
+
+    public static void validatePetWeight(Weight petWeight) {
+        if (petWeight == null) {
+            throw new IllegalArgumentException("Invalid pet weight: must be SMALL, MEDIUM, or LARGE.");
+        }
+    }
+
+    public static void validateBreed(Breed breed) {
+        if (breed == null) {
+            throw new IllegalArgumentException("Invalid breed: must be a valid value.");
+        }
+    }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
@@ -16,6 +16,7 @@ import ddog.user.application.mapper.UserMapper;
 import ddog.user.presentation.account.dto.*;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccountService {

--- a/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
@@ -62,7 +62,7 @@ public class AccountService {
 
     @Transactional
     public SignUpResp signUpWithPet(SignUpWithPet request, HttpServletResponse response) {
-        if(this.hasInValidSignUpRequestDataFormat(request))
+        if(this.hasInValidSignUpWithPetDataFormat(request))
             throw new AccountException(AccountExceptionType.INVALID_REQUEST_DATA_FORMAT);
 
         Account accountToSave = Account.createUser(request.getEmail(), Role.DAENGLE);
@@ -82,6 +82,9 @@ public class AccountService {
 
     @Transactional
     public SignUpResp signUpWithoutPet(SignUpWithoutPet request, HttpServletResponse response) {
+        if(this.hasInValidSignUpWithoutPetDataFormat(request))
+            throw new AccountException(AccountExceptionType.INVALID_REQUEST_DATA_FORMAT);
+
         Account accountToSave = Account.createUser(request.getEmail(), Role.DAENGLE);
         Account savedAccount = accountPersist.save(accountToSave);
         User user = UserMapper.createWithoutPet(savedAccount.getAccountId(), request);
@@ -145,7 +148,7 @@ public class AccountService {
         petPersist.deletePetById(petId);
     }
 
-    private boolean hasInValidSignUpRequestDataFormat(SignUpWithPet request) {
+    private boolean hasInValidSignUpWithPetDataFormat(SignUpWithPet request) {
         try {
             Account.validateUsername(request.getUsername());
             Account.validatePhoneNumber(request.getPhoneNumber());
@@ -157,6 +160,19 @@ public class AccountService {
             Pet.validatePetGender(request.getPetGender());
             Pet.validatePetWeight(request.getPetWeight());
             Pet.validateBreed(request.getBreed());
+
+            return false; // 모든 유효성 검사 통과
+        } catch (IllegalArgumentException e) {
+            return true; // 유효성 검사 실패
+        }
+    }
+
+    private boolean hasInValidSignUpWithoutPetDataFormat(SignUpWithoutPet request) {
+        try {
+            Account.validateUsername(request.getUsername());
+            Account.validatePhoneNumber(request.getPhoneNumber());
+            Account.validateNickname(request.getNickname());
+            Account.validateAddress(request.getAddress());
 
             return false; // 모든 유효성 검사 통과
         } catch (IllegalArgumentException e) {

--- a/daengle-user-api/src/main/java/ddog/user/application/exception/AccountExceptionType.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/exception/AccountExceptionType.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AccountExceptionType {
+    INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
     ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
     NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
 

--- a/daengle-user-api/src/main/java/ddog/user/application/exception/common/GlobalControllerAdvice.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/exception/common/GlobalControllerAdvice.java
@@ -3,6 +3,7 @@ package ddog.user.application.exception.common;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -38,6 +39,18 @@ public class GlobalControllerAdvice {
                         new CustomError(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR, null)
                 ),
                 HttpStatus.INTERNAL_SERVER_ERROR
+        );
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)  //ENUM 값 불일치
+    public ResponseEntity<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        return new ResponseEntity<>(
+                new CommonResponseEntity<>(
+                        false,
+                        null,
+                        new CustomError(e.getMessage(), HttpStatus.BAD_REQUEST, null)
+                ),
+                HttpStatus.BAD_REQUEST
         );
     }
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 사용자 등록 API 요청값 포멧의 유효성을 검사하는 로직을 추가 구현했습니다
    - 각 유효성 검사를 통해 유요하지않은 웹서버 요청으로부터 400번 에러를 응답합니다
    - 전역 예외처리에 ENUM 값 오류에 대한 헨들링을 추가했습니다

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
