### PR TITLE
[refactoring/daengle-35] 미용사/수의사 등록 API 요청 데이터 유효성 검사 로직 구현

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/account/Account.java
+++ b/daengle-domain/src/main/java/ddog/domain/account/Account.java
@@ -30,28 +30,4 @@ public class Account {
                 .status(Status.PENDING)
                 .build();
     }
-
-    public static void validateUsername(String username) {
-        if (username == null || username.length() < 2 || username.length() > 10) {
-            throw new IllegalArgumentException("Invalid username: must be 2-10 characters.");
-        }
-    }
-
-    public static void validatePhoneNumber(String phoneNumber) {
-        if (phoneNumber == null || !phoneNumber.matches("^010-\\d{4}-\\d{4}$")) {
-            throw new IllegalArgumentException("Invalid phone number: must follow format 010-0000-0000.");
-        }
-    }
-
-    public static void validateNickname(String nickname) {
-        if (nickname == null || nickname.length() < 2 || nickname.length() > 10) {
-            throw new IllegalArgumentException("Invalid nickname: must be 2-10 characters.");
-        }
-    }
-
-    public static void validateAddress(String address) {
-        if (address == null || !address.matches("^\\S+시 \\S+구 \\S+동$")) {
-            throw new IllegalArgumentException("Invalid address: must follow format '00시 00구 00동'.");
-        }
-    }/**/
 }

--- a/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
@@ -27,4 +27,46 @@ public class Groomer {
     private List<String> businessLicenses;
     private List<String> licenses;
 
+    public static void validateShopName(String shopName) {
+        if (shopName == null || !shopName.matches("^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9\\s]{0,19}$")) {
+            throw new IllegalArgumentException("Shop name must be 1-20 characters long and can contain Korean, " +
+                    "English letters, numbers, and spaces, but cannot start or end with a space.");
+        }
+    }
+
+    public static void validateName(String name) {
+        if (name == null || !name.matches("^[가-힣]{2,10}$")) {
+            throw new IllegalArgumentException("Name must be 2-10 Korean characters.");
+        }
+    }
+
+    public static void validatePhoneNumber(String phoneNumber) {
+        if (phoneNumber == null || !phoneNumber.matches("^010-\\d{4}-\\d{4}$")) {
+            throw new IllegalArgumentException("Phone number must be in the format 010-0000-0000.");
+        }
+    }
+
+    public static void validateAddress(String address) {
+        if (address == null || !address.matches("^[가-힣a-zA-Z\\s]+\\s[가-힣a-zA-Z\\s]+\\s[가-힣a-zA-Z\\s]+$")) {
+            throw new IllegalArgumentException("Address must be in the format 'City District Neighborhood' separated by spaces.");
+        }
+    }
+
+    public static void validateDetailAddress(String detailAddress) {
+        if (detailAddress.length() > 20) {
+            throw new IllegalArgumentException("Detail address must be 20 characters or less.");
+        }
+    }
+
+    public static void validateBusinessLicenses(List<String> businessLicenses) {
+        if (businessLicenses == null || businessLicenses.isEmpty() || businessLicenses.size() > 2) {
+            throw new IllegalArgumentException("Business licenses must contain between 1 and 2 entries.");
+        }
+    }
+
+    public static void validateLicenses(List<String> licenses) {
+        if (licenses == null || licenses.isEmpty() || licenses.size() > 2) {
+            throw new IllegalArgumentException("Licenses must contain between 1 and 2 entries.");
+        }
+    }
 }

--- a/daengle-domain/src/main/java/ddog/domain/pet/Breed.java
+++ b/daengle-domain/src/main/java/ddog/domain/pet/Breed.java
@@ -46,7 +46,9 @@ public enum Breed {
     POMERANIAN("포메라니안"),
     POODLE("푸들"),
     KOREAN_MASTIFF("한국 토종 마스티프"),
-    WHIPPET("휘핏");
+    WHIPPET("휘핏"),
+
+    ETC("기타");
 
     private String name;
 }

--- a/daengle-domain/src/main/java/ddog/domain/user/User.java
+++ b/daengle-domain/src/main/java/ddog/domain/user/User.java
@@ -55,4 +55,27 @@ public class User {
                 .build();
     }
 
+    public static void validateUsername(String username) {
+        if (username == null || username.length() < 2 || username.length() > 10) {
+            throw new IllegalArgumentException("Invalid username: must be 2-10 characters.");
+        }
+    }
+
+    public static void validatePhoneNumber(String phoneNumber) {
+        if (phoneNumber == null || !phoneNumber.matches("^010-\\d{4}-\\d{4}$")) {
+            throw new IllegalArgumentException("Invalid phone number: must follow format 010-0000-0000.");
+        }
+    }
+
+    public static void validateNickname(String nickname) {
+        if (nickname == null || nickname.length() < 2 || nickname.length() > 10) {
+            throw new IllegalArgumentException("Invalid nickname: must be 2-10 characters.");
+        }
+    }
+
+    public static void validateAddress(String address) {
+        if (address == null || !address.matches("^\\S+시 \\S+구 \\S+동$")) {
+            throw new IllegalArgumentException("Invalid address: must follow format '00시 00구 00동'.");
+        }
+    }
 }

--- a/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
@@ -1,12 +1,13 @@
 package ddog.domain.vet;
 
-import ddog.domain.account.Status;
+import ddog.domain.vet.enums.AreaCode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.List;
 
 @Getter
@@ -29,4 +30,43 @@ public class Vet {
     private LocalTime endTime;
     private List<Day> closedDays;
     private List<String> licenses;
+
+    public static void validateName(String name) {
+        if (name == null || name.length() < 2 || name.length() > 10 || !name.matches("^[가-힣\\s]+$")) {
+            throw new IllegalArgumentException("Invalid name: must be 2-10 characters and in Korean.");
+        }
+    }
+
+    public static void validateAddress(String address) {
+        if (address == null || !address.matches("^\\S+시 \\S+구 \\S+동$")) {
+            throw new IllegalArgumentException("Invalid address: must follow the format '00시 00구 00동'.");
+        }
+    }
+
+    public static void validateDetailAddress(String detailAddress) {
+        if (detailAddress == null || detailAddress.length() > 20) {
+            throw new IllegalArgumentException("Invalid detail address: must be up to 20 characters.");
+        }
+    }
+
+    public static void validatePhoneNumber(String phoneNumber) {
+        // 1. 기본 형식 확인
+        if (phoneNumber == null || !phoneNumber.matches("^\\d{2,3}-\\d{3,4}-\\d{4}$")) {
+            throw new IllegalArgumentException("Invalid phone number: must follow the format {area code}-{number}.");
+        }
+
+        // 2. 지역번호 확인
+        String[] parts = phoneNumber.split("-");
+        String areaCode = parts[0];
+
+        boolean isInValidAreaCode = Arrays.stream(AreaCode.values())
+                .noneMatch(code -> code.getCode().equals(areaCode));
+
+        if (isInValidAreaCode) {
+            throw new IllegalArgumentException("Invalid area code: " + areaCode + ". Must be a valid Korean area code.");
+        }
+    }
+
+    public static void validateLicenses(List<String> licenses) { //현재 별다른 예외 처리 없음
+    }
 }

--- a/daengle-domain/src/main/java/ddog/domain/vet/enums/AreaCode.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/enums/AreaCode.java
@@ -1,0 +1,36 @@
+package ddog.domain.vet.enums;
+
+public enum AreaCode {
+
+    SEOUL("02"),
+    GYEONGGI("031"),
+    INCHEON("032"),
+    GANGWON("033"),
+    CHUNGNAM("041"),
+    DAEJEON("042"),
+    CHUNGBUK("043"),
+    SEJONG("044"),
+    BUSAN("051"),
+    ULSAN("052"),
+    DAEGU("053"),
+    GYEONGBUK("054"),
+    GYEONGNAM("055"),
+    JEONNAM("061"),
+    GWANGJU("062"),
+    JEONBUK("063"),
+    JEJU("064"),
+
+    MOBILE("010"), // 휴대전화 번호
+    SAFETY("050"), // 안심번호
+    INTERNET("070"); // 인터넷전화
+
+    private final String code;
+
+    AreaCode(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -70,6 +70,4 @@ public class AccountService {
         Groomer updatedGroomer = GroomerMapper.withUpdate(groomer, request);
         groomerPersist.save(updatedGroomer);
     }
-
-
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -4,8 +4,8 @@ import ddog.auth.config.jwt.JwtTokenProvider;
 import ddog.domain.account.Account;
 import ddog.domain.account.Role;
 import ddog.domain.groomer.Groomer;
-import ddog.groomer.application.exception.AccountException;
-import ddog.groomer.application.exception.AccountExceptionType;
+import ddog.groomer.application.exception.GroomerException;
+import ddog.groomer.application.exception.GroomerExceptionType;
 import ddog.groomer.application.mapper.GroomerMapper;
 import ddog.groomer.presentation.account.dto.ModifyInfoReq;
 import ddog.groomer.presentation.account.dto.ProfileInfo;
@@ -39,7 +39,7 @@ public class AccountService {
     @Transactional
     public SignUpResp signUp(SignUpReq request, HttpServletResponse response) {
         if (this.hasInvalidGroomerDataFormat(request)) {
-            throw new AccountException(AccountExceptionType.INVALID_REQUEST_DATA_FORMAT);
+            throw new GroomerException(GroomerExceptionType.INVALID_REQUEST_DATA_FORMAT);
         }
 
         Account newAccount = Account.create(request.getEmail(), Role.GROOMER);
@@ -82,17 +82,11 @@ public class AccountService {
     private boolean hasInvalidGroomerDataFormat(SignUpReq request) {
         try {
             Groomer.validateShopName(request.getShopName());
-            log.info("1");
             Groomer.validateName(request.getName());
-            log.info("2");
             Groomer.validatePhoneNumber(request.getPhoneNumber());
-            log.info("3");
             Groomer.validateAddress(request.getAddress());
-            log.info("4");
             Groomer.validateDetailAddress(request.getDetailAddress());
-            log.info("5");
             Groomer.validateBusinessLicenses(request.getBusinessLicenses());
-            log.info("6");
             Groomer.validateLicenses(request.getLicenses());
 
             return false; // 모든 유효성 검사 통과

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -4,6 +4,8 @@ import ddog.auth.config.jwt.JwtTokenProvider;
 import ddog.domain.account.Account;
 import ddog.domain.account.Role;
 import ddog.domain.groomer.Groomer;
+import ddog.groomer.application.exception.AccountException;
+import ddog.groomer.application.exception.AccountExceptionType;
 import ddog.groomer.application.mapper.GroomerMapper;
 import ddog.groomer.presentation.account.dto.ModifyInfoReq;
 import ddog.groomer.presentation.account.dto.ProfileInfo;
@@ -13,6 +15,7 @@ import ddog.persistence.port.AccountPersist;
 import ddog.persistence.port.GroomerPersist;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -24,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Collection;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccountService {
@@ -34,6 +38,10 @@ public class AccountService {
 
     @Transactional
     public SignUpResp signUp(SignUpReq request, HttpServletResponse response) {
+        if (this.hasInvalidGroomerDataFormat(request)) {
+            throw new AccountException(AccountExceptionType.INVALID_REQUEST_DATA_FORMAT);
+        }
+
         Account newAccount = Account.create(request.getEmail(), Role.GROOMER);
         Account savedAccount = accountPersist.save(newAccount);
 
@@ -69,5 +77,27 @@ public class AccountService {
         Groomer groomer = groomerPersist.getGroomerByAccountId(accountId);
         Groomer updatedGroomer = GroomerMapper.withUpdate(groomer, request);
         groomerPersist.save(updatedGroomer);
+    }
+
+    private boolean hasInvalidGroomerDataFormat(SignUpReq request) {
+        try {
+            Groomer.validateShopName(request.getShopName());
+            log.info("1");
+            Groomer.validateName(request.getName());
+            log.info("2");
+            Groomer.validatePhoneNumber(request.getPhoneNumber());
+            log.info("3");
+            Groomer.validateAddress(request.getAddress());
+            log.info("4");
+            Groomer.validateDetailAddress(request.getDetailAddress());
+            log.info("5");
+            Groomer.validateBusinessLicenses(request.getBusinessLicenses());
+            log.info("6");
+            Groomer.validateLicenses(request.getLicenses());
+
+            return false; // 모든 유효성 검사 통과
+        } catch (IllegalArgumentException e) {
+            return true; // 유효성 검사 실패
+        }
     }
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/AccountExceptionType.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/AccountExceptionType.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AccountExceptionType {
+    INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
     ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
     NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
 

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/GroomerException.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/GroomerException.java
@@ -1,0 +1,9 @@
+package ddog.groomer.application.exception;
+
+import ddog.groomer.application.exception.common.CustomRuntimeException;
+
+public class GroomerException extends CustomRuntimeException {
+    public GroomerException(GroomerExceptionType type, Object... args) {
+        super(type.getMessage(), type.getHttpStatus(), type.getCode());
+    }
+}

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/GroomerExceptionType.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/GroomerExceptionType.java
@@ -1,0 +1,15 @@
+package ddog.groomer.application.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GroomerExceptionType {
+    INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+}

--- a/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
@@ -11,6 +11,8 @@ import ddog.persistence.port.PetPersist;
 import ddog.persistence.port.UserPersist;
 import ddog.user.application.exception.AccountException;
 import ddog.user.application.exception.AccountExceptionType;
+import ddog.user.application.exception.UserException;
+import ddog.user.application.exception.UserExceptionType;
 import ddog.user.application.mapper.PetMapper;
 import ddog.user.application.mapper.UserMapper;
 import ddog.user.presentation.account.dto.*;
@@ -63,7 +65,7 @@ public class AccountService {
     @Transactional
     public SignUpResp signUpWithPet(SignUpWithPet request, HttpServletResponse response) {
         if(this.hasInValidSignUpWithPetDataFormat(request))
-            throw new AccountException(AccountExceptionType.INVALID_REQUEST_DATA_FORMAT);
+            throw new UserException(UserExceptionType.INVALID_REQUEST_DATA_FORMAT);
 
         Account accountToSave = Account.createUser(request.getEmail(), Role.DAENGLE);
         Account savedAccount = accountPersist.save(accountToSave);

--- a/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
@@ -150,10 +150,10 @@ public class AccountService {
 
     private boolean hasInValidSignUpWithPetDataFormat(SignUpWithPet request) {
         try {
-            Account.validateUsername(request.getUsername());
-            Account.validatePhoneNumber(request.getPhoneNumber());
-            Account.validateNickname(request.getNickname());
-            Account.validateAddress(request.getAddress());
+            User.validateUsername(request.getUsername());
+            User.validatePhoneNumber(request.getPhoneNumber());
+            User.validateNickname(request.getNickname());
+            User.validateAddress(request.getAddress());
 
             Pet.validatePetName(request.getPetName());
             Pet.validatePetBirth(request.getPetBirth());
@@ -169,10 +169,10 @@ public class AccountService {
 
     private boolean hasInValidSignUpWithoutPetDataFormat(SignUpWithoutPet request) {
         try {
-            Account.validateUsername(request.getUsername());
-            Account.validatePhoneNumber(request.getPhoneNumber());
-            Account.validateNickname(request.getNickname());
-            Account.validateAddress(request.getAddress());
+            User.validateUsername(request.getUsername());
+            User.validatePhoneNumber(request.getPhoneNumber());
+            User.validateNickname(request.getNickname());
+            User.validateAddress(request.getAddress());
 
             return false; // 모든 유효성 검사 통과
         } catch (IllegalArgumentException e) {

--- a/daengle-vet-api/src/main/java/ddog/vet/application/exception/VetException.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/exception/VetException.java
@@ -1,0 +1,9 @@
+package ddog.vet.application.exception;
+
+import ddog.vet.application.exception.common.CustomRuntimeException;
+
+public class VetException extends CustomRuntimeException {
+    public VetException(VetExceptionType type, Object... args) {
+        super(type.getMessage(), type.getHttpStatus(), type.getCode());
+    }
+}

--- a/daengle-vet-api/src/main/java/ddog/vet/application/exception/VetExceptionType.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/exception/VetExceptionType.java
@@ -1,12 +1,11 @@
-package ddog.user.application.exception;
+package ddog.vet.application.exception;
 
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
-public enum UserExceptionType {
-    INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 1001, "사용자가 존재하지 않음.");
+public enum VetExceptionType {
+    INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류");
 
     private final HttpStatus httpStatus;
     private final Integer code;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 미용사/수의사 등록 API 요청 값에 사전 합의되지않은 형식의 데이터를 예외처리합니다 (400 응답)
    - 최소/최대 글자 수 규칙 확인
    - 전화번호 맨 앞자리 지역번호 내 존재하는 번호인지 확인
    - 주소 00시 00구 00동 양식 등등
    - 모두 정규식으로 구현
    - 모든 정규식은 해당 도메인 객체 내 클래스 메서드로 존재

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
