### PR TITLE
[feat/daengle-40] 리뷰 도메인 엔티티 및 jpa 영속성 객체 구현

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
@@ -46,10 +46,10 @@ public class Groomer {
         }
     }
 
-    public static void validateAddress(String address) {
-        if (address == null || !address.matches("^[가-힣a-zA-Z\\s]+\\s[가-힣a-zA-Z\\s]+\\s[가-힣a-zA-Z\\s]+$")) {
-            throw new IllegalArgumentException("Address must be in the format 'City District Neighborhood' separated by spaces.");
-        }
+    public static void validateAddress(String address) { //TODO 공공 데이터 추가 후 재작업
+//        if (address == null || !address.matches("^[가-힣a-zA-Z\\s]+\\s[가-힣a-zA-Z\\s]+\\s[가-힣a-zA-Z\\s]+$")) {
+//            throw new IllegalArgumentException("Address must be in the format 'City District Neighborhood' separated by spaces.");
+//        }
     }
 
     public static void validateDetailAddress(String detailAddress) {

--- a/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
@@ -13,5 +13,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CareReview extends Review {
-    List<CareKeywordReview> careKeywordReviewList;
+    private Long careReviewId;
+    private List<CareKeywordReview> careKeywordReviewList;
 }

--- a/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
@@ -2,7 +2,6 @@ package ddog.domain.review;
 
 import ddog.domain.review.enums.CareKeywordReview;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;

--- a/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
@@ -1,0 +1,18 @@
+package ddog.domain.review;
+
+import ddog.domain.review.enums.CareKeywordReview;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareReview extends Review {
+    List<CareKeywordReview> careKeywordReviewList;
+}

--- a/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
@@ -1,0 +1,18 @@
+package ddog.domain.review;
+
+import ddog.domain.review.enums.GroomingKeywordReview;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroomingReview extends Review {
+    List<GroomingKeywordReview> groomingKeywordReviewList;
+}

--- a/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
@@ -14,5 +14,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GroomingReview extends Review {
-    List<GroomingKeywordReview> groomingKeywordReviewList;
+    private Long groomingReviewId;
+    private List<GroomingKeywordReview> groomingKeywordReviewList;
 }

--- a/daengle-domain/src/main/java/ddog/domain/review/Review.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/Review.java
@@ -13,9 +13,10 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public abstract class Review {
-    private Long reservationId;
+    private Long reviewId;
     private Long reviewerId;
     private Long revieweeId;
+    private Long reviewCount;
     private Long starRating;
     private String content;
     private LocalDateTime createTime;

--- a/daengle-domain/src/main/java/ddog/domain/review/Review.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/Review.java
@@ -1,0 +1,21 @@
+package ddog.domain.review;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class Review {
+    private Long reservationId;
+    private Long reviewerId;
+    private Long revieweeId;
+    private Long starRating;
+    private String content;
+    private List<String> imageUrlList;
+}

--- a/daengle-domain/src/main/java/ddog/domain/review/Review.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/Review.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -17,5 +18,6 @@ public abstract class Review {
     private Long revieweeId;
     private Long starRating;
     private String content;
+    private LocalDateTime createTime;
     private List<String> imageUrlList;
 }

--- a/daengle-domain/src/main/java/ddog/domain/review/enums/CareKeywordReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/enums/CareKeywordReview.java
@@ -1,4 +1,17 @@
 package ddog.domain.review.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum CareKeywordReview {
+    EXCELLENT_CONSULTATION("상담을 잘해줘요"),
+    HYGIENIC("위생적이에요"),
+    CUSTOMIZED_CARE("맞춤케어를 잘해줘요"),
+
+    //진료
+    PROFESSIONAL("전문성이 돋보여요");
+
+    public final String keyword;
 }

--- a/daengle-domain/src/main/java/ddog/domain/review/enums/CareKeywordReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/enums/CareKeywordReview.java
@@ -1,0 +1,4 @@
+package ddog.domain.review.enums;
+
+public enum CareKeywordReview {
+}

--- a/daengle-domain/src/main/java/ddog/domain/review/enums/GroomingKeywordReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/enums/GroomingKeywordReview.java
@@ -1,0 +1,4 @@
+package ddog.domain.review.enums;
+
+public enum GroomingKeywordReview {
+}

--- a/daengle-domain/src/main/java/ddog/domain/review/enums/GroomingKeywordReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/enums/GroomingKeywordReview.java
@@ -1,4 +1,17 @@
 package ddog.domain.review.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum GroomingKeywordReview {
+    EXCELLENT_CONSULTATION("상담을 잘해줘요"),
+    HYGIENIC("위생적이에요"),
+    CUSTOMIZED_CARE("맞춤케어를 잘해줘요"),
+
+    //미용
+    STYLE_IS_GREAT("스타일이 최고예요");
+
+    private final String keyword;
 }

--- a/daengle-domain/src/main/java/ddog/domain/user/User.java
+++ b/daengle-domain/src/main/java/ddog/domain/user/User.java
@@ -73,9 +73,9 @@ public class User {
         }
     }
 
-    public static void validateAddress(String address) {
-        if (address == null || !address.matches("^\\S+시 \\S+구 \\S+동$")) {
-            throw new IllegalArgumentException("Invalid address: must follow format '00시 00구 00동'.");
-        }
+    public static void validateAddress(String address) { //TODO 공공데이터 추가 후 재작업
+//        if (address == null || !address.matches("^\\S+시 \\S+구 \\S+동$")) {
+//            throw new IllegalArgumentException("Invalid address: must follow format '00시 00구 00동'.");
+//        }
     }
 }

--- a/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
@@ -37,10 +37,10 @@ public class Vet {
         }
     }
 
-    public static void validateAddress(String address) {
-        if (address == null || !address.matches("^\\S+시 \\S+구 \\S+동$")) {
-            throw new IllegalArgumentException("Invalid address: must follow the format '00시 00구 00동'.");
-        }
+    public static void validateAddress(String address) {  //TODO 공공데이터 추가 후 재작업
+//        if (address == null || !address.matches("^\\S+시 \\S+구 \\S+동$")) {
+//            throw new IllegalArgumentException("Invalid address: must follow the format '00시 00구 00동'.");
+//        }
     }
 
     public static void validateDetailAddress(String detailAddress) {

--- a/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/CareReviewJpaEntity.java
+++ b/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/CareReviewJpaEntity.java
@@ -34,6 +34,7 @@ public class CareReviewJpaEntity {
 
     @ElementCollection // 키워드 리스트
     @CollectionTable(name = "care_review_keyword_list", joinColumns = @JoinColumn(name = "care_review_id"))
+    @Enumerated(EnumType.STRING)
     @Column(name = "keyword_list")
     private List<CareKeywordReview> careKeywordReviewList;
 

--- a/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/CareReviewJpaEntity.java
+++ b/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/CareReviewJpaEntity.java
@@ -1,0 +1,67 @@
+package ddog.persistence.jpa.entity;
+
+import ddog.domain.review.CareReview;
+import ddog.domain.review.enums.CareKeywordReview;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "CareReviews")
+public class CareReviewJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long careReviewId;
+    private Long reviewerId;
+    private Long revieweeId;
+    private Long reviewCount;
+    private Long starRating;
+    private String content;
+    private LocalDateTime createTime;
+
+    @ElementCollection // 이미지 URL 리스트
+    @CollectionTable(name = "care_review_image_url_list", joinColumns = @JoinColumn(name = "care_review_id"))
+    @Column(name = "image_url_list")
+    private List<String> imageUrlList;
+
+    @ElementCollection // 키워드 리스트
+    @CollectionTable(name = "care_review_keyword_list", joinColumns = @JoinColumn(name = "care_review_id"))
+    @Column(name = "keyword_list")
+    private List<CareKeywordReview> careKeywordReviewList;
+
+    public static CareReviewJpaEntity from (CareReview careReview) {
+        return CareReviewJpaEntity.builder()
+                .careReviewId(careReview.getCareReviewId())
+                .reviewerId(careReview.getReviewerId())
+                .revieweeId(careReview.getRevieweeId())
+                .reviewCount(careReview.getReviewCount())
+                .starRating(careReview.getStarRating())
+                .content(careReview.getContent())
+                .createTime(careReview.getCreateTime())
+                .imageUrlList(careReview.getImageUrlList())
+                .careKeywordReviewList(careReview.getCareKeywordReviewList())
+                .build();
+    }
+
+    public CareReview toModel() {
+        return CareReview.builder()
+                .careReviewId(careReviewId)
+                .reviewerId(reviewerId)
+                .revieweeId(revieweeId)
+                .reviewCount(reviewCount)
+                .starRating(starRating)
+                .content(content)
+                .createTime(createTime)
+                .imageUrlList(imageUrlList)
+                .careKeywordReviewList(careKeywordReviewList)
+                .build();
+    }
+}

--- a/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/GroomerJpaEntity.java
+++ b/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/GroomerJpaEntity.java
@@ -35,10 +35,10 @@ public class GroomerJpaEntity {
     @CollectionTable(name = "groomer_business_licenses", joinColumns = @JoinColumn(name = "groomer_id"))
     @Column(name = "business_license_url")
     private List<String> businessLicenses;
-
     @ElementCollection // 자격증 URL 리스트
     @CollectionTable(name = "groomer_licenses", joinColumns = @JoinColumn(name = "groomer_id"))
     @Column(name = "license_url")
+
     private List<String> licenses;
 
     public static GroomerJpaEntity from(Groomer groomer) {

--- a/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/GroomingReviewJpaEntity.java
+++ b/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/GroomingReviewJpaEntity.java
@@ -34,6 +34,7 @@ public class GroomingReviewJpaEntity {
 
     @ElementCollection // 키워드 리스트
     @CollectionTable(name = "grooming_review_keyword_list", joinColumns = @JoinColumn(name = "grooming_review_id"))
+    @Enumerated(EnumType.STRING)
     @Column(name = "keyword_list")
     private List<GroomingKeywordReview> groomingKeywordReviewList;
 

--- a/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/GroomingReviewJpaEntity.java
+++ b/daengle-persistence/src/main/java/ddog/persistence/jpa/entity/GroomingReviewJpaEntity.java
@@ -1,0 +1,67 @@
+package ddog.persistence.jpa.entity;
+
+import ddog.domain.review.GroomingReview;
+import ddog.domain.review.enums.GroomingKeywordReview;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "GroomingReviews")
+public class GroomingReviewJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long groomingReviewId;
+    private Long reviewerId;
+    private Long revieweeId;
+    private Long reviewCount;
+    private Long starRating;
+    private String content;
+    private LocalDateTime createTime;
+
+    @ElementCollection // 이미지 URL 리스트
+    @CollectionTable(name = "grooming_review_image_url_list", joinColumns = @JoinColumn(name = "grooming_review_id"))
+    @Column(name = "image_url_list")
+    private List<String> imageUrlList;
+
+    @ElementCollection // 키워드 리스트
+    @CollectionTable(name = "grooming_review_keyword_list", joinColumns = @JoinColumn(name = "grooming_review_id"))
+    @Column(name = "keyword_list")
+    private List<GroomingKeywordReview> groomingKeywordReviewList;
+
+    public static GroomingReviewJpaEntity from(GroomingReview groomingReview) {
+        return GroomingReviewJpaEntity.builder()
+                .groomingReviewId(groomingReview.getGroomingReviewId())
+                .reviewerId(groomingReview.getReviewerId())
+                .revieweeId(groomingReview.getRevieweeId())
+                .reviewCount(groomingReview.getReviewCount())
+                .starRating(groomingReview.getStarRating())
+                .content(groomingReview.getContent())
+                .createTime(groomingReview.getCreateTime())
+                .imageUrlList(groomingReview.getImageUrlList())
+                .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
+                .build();
+    }
+
+    public GroomingReview toModel() {
+        return GroomingReview.builder()
+                .groomingReviewId(groomingReviewId)
+                .reviewerId(reviewerId)
+                .revieweeId(revieweeId)
+                .reviewCount(reviewCount)
+                .starRating(starRating)
+                .content(content)
+                .createTime(createTime)
+                .imageUrlList(imageUrlList)
+                .groomingKeywordReviewList(groomingKeywordReviewList)
+                .build();
+    }
+}


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 리뷰 도메인 엔티티를 구현했습니다.
    - 이때, '리뷰'는 데이터가 아닌 추상적인 개념으로서, 이를 구현한 '미용 리뷰', '진료 리뷰'만이 인스턴스로 만들어지고 화면에 컴포넌트로 표현됩니다.
    - 때문에, 리뷰 도메인 엔티티는 추상클래스로 구현하고, 이를 상속한 미용 리뷰와 진료 리뷰 pojo 객체를 만들었습니다
    - 단, 데이터적인 측면에 리뷰라는 엔티티는 없기 때문에 리뷰 테이블은 만들지 않았으며, 데이터 영속이 필요한 미용 리뷰와 진료 리뷰 테이블만 존재합니다. 즉, 리뷰 DB엔티티는 없음. 
    - 이와 같은 원리로 '견적'도메인도 추상적인 개념이기 때문에, 추상클래스로 변경하고 이를 구체화한 미용 견적, 진료 견적만 일반 클래스로 구현하기를 제안합니다. 

   **정리** 
```

- 도메인엔티티 3개 -> 추상클래스인 리뷰 객체와 자식 객체인 미용/진료 리뷰 객체
- DB엔티티 2개 -> 미용/진료 테이블의 튜플
- jpa 영속성 엔티티 2개 -> 미용/진료 jpa 엔티티

```

<br>

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

     - Builder 패턴 쓰실거면 SupoerBuilder로 변경해야함 (상속관계에서 필요)
    

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : Yes

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
