### PR TITLE
[feat/daengle-51] 모놀로식 레포 & 단일 서버 환경에서의 외부 API(PortOne) 타임아웃 테스트 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 
     // Resilience4j
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
+    implementation 'io.github.resilience4j:resilience4j-timelimiter'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
 
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // Resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
 }
 
 test {

--- a/src/main/java/ddog/daengleserver/application/PaymentService.java
+++ b/src/main/java/ddog/daengleserver/application/PaymentService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.sql.Time;
 
 @Slf4j
 @Service
@@ -45,6 +46,8 @@ public class PaymentService implements PaymentUseCase {
         Payment payment = order.getPayment();
 
         try {
+            Thread.sleep(5000); //포트원 API 타임에러 상황 가정
+
             com.siot.IamportRestClient.response.Payment iamportResp =
                     iamportClient.paymentByImpUid(paymentCallbackReq.getPaymentUid()).getResponse();
 
@@ -56,6 +59,8 @@ public class PaymentService implements PaymentUseCase {
 
         } catch (IamportResponseException | IOException e) {
             throw new PaymentException(PaymentExceptionType.PAYMENT_PG_INTEGRATION_FAILED);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ddog/daengleserver/application/PaymentService.java
+++ b/src/main/java/ddog/daengleserver/application/PaymentService.java
@@ -14,6 +14,7 @@ import ddog.daengleserver.domain.exception.PaymentException;
 import ddog.daengleserver.presentation.dto.request.PaymentCallbackReq;
 import ddog.daengleserver.presentation.dto.response.PaymentCallbackResp;
 import ddog.daengleserver.presentation.usecase.PaymentUseCase;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,44 +34,62 @@ public class PaymentService implements PaymentUseCase {
 
     @Override
     @Transactional
+    @CircuitBreaker(name = "paymentValidation", fallbackMethod = "fallbackValidationPayment")
     public PaymentCallbackResp validationPayment(PaymentCallbackReq paymentCallbackReq) {
-        Order order = orderRepository.findBy(paymentCallbackReq.getOrderUid()).orElseThrow(() -> new OrderException(OrderExceptionType.ORDER_NOT_FOUNDED));
+        return executePaymentValidation(paymentCallbackReq);
+    }
+
+    private PaymentCallbackResp executePaymentValidation(PaymentCallbackReq paymentCallbackReq) {
+        Order order = orderRepository.findBy(paymentCallbackReq.getOrderUid())
+                .orElseThrow(() -> new OrderException(OrderExceptionType.ORDER_NOT_FOUNDED));
         Payment payment = order.getPayment();
 
         try {
             com.siot.IamportRestClient.response.Payment iamportResp =
                     iamportClient.paymentByImpUid(paymentCallbackReq.getPaymentUid()).getResponse();
-            String paymentStatus = iamportResp.getStatus();
-            long paymentAmount = iamportResp.getAmount().longValue();
 
-            //결제 완료 검증
-            if(payment.checkIncompleteBy(paymentStatus)) {  //TODO 결제상태 변경과 영속도 도메인 엔티티에게 위임하기
-                payment.cancel();
-                paymentRepository.save(payment);
+            validatePaymentStatus(payment, iamportResp);
+            validatePaymentAmount(payment, iamportResp);
 
-                throw new PaymentException(PaymentExceptionType.PAYMENT_PG_INCOMPLETE);
-            }
-
-            //결제 금액 검증
-            if(payment.checkInValidationBy(paymentAmount)) {    //TODO 결제상태 변경과 영속도 도메인 엔티티에게 위임하기
-                payment.cancel();
-                paymentRepository.save(payment);
-                iamportClient.cancelPaymentByImpUid(new CancelData(iamportResp.getImpUid(), true, new BigDecimal(paymentAmount)));
-
-                throw new PaymentException(PaymentExceptionType.PAYMENT_PG_AMOUNT_MISMATCH);
-            }
-
-            //결제 검증 절차 성공
             payment.validationSuccess(iamportResp.getImpUid());
-
-            return PaymentCallbackResp.builder()
-                    .userId(order.getAccountId())
-                    .paymentId(payment.getPaymentId())
-                    .price(payment.getPrice())
-                    .build();
+            return createSuccessResponse(order, payment);
 
         } catch (IamportResponseException | IOException e) {
             throw new PaymentException(PaymentExceptionType.PAYMENT_PG_INTEGRATION_FAILED);
         }
+    }
+
+    private void fallbackValidationPayment(PaymentCallbackReq paymentCallbackReq, Throwable throwable) {
+        log.error("Circuit breaker activated for order {}: {}", paymentCallbackReq.getOrderUid(), throwable.getMessage());
+
+        throw new PaymentException(PaymentExceptionType.PAYMENT_PG_SYSTEM_TIMEOUT);
+    }
+
+    private void validatePaymentStatus(Payment payment, com.siot.IamportRestClient.response.Payment iamportResp) {
+        if (payment.checkIncompleteBy(iamportResp.getStatus())) {
+            payment.cancel();
+            paymentRepository.save(payment);
+            throw new PaymentException(PaymentExceptionType.PAYMENT_PG_INCOMPLETE);
+        }
+    }
+
+    private void validatePaymentAmount(Payment payment, com.siot.IamportRestClient.response.Payment iamportResp) throws IamportResponseException, IOException {
+        long paymentAmount = iamportResp.getAmount().longValue();
+        if (payment.checkInValidationBy(paymentAmount)) {
+            payment.cancel();
+            paymentRepository.save(payment);
+            iamportClient.cancelPaymentByImpUid(
+                    new CancelData(iamportResp.getImpUid(), true, new BigDecimal(paymentAmount))
+            );
+            throw new PaymentException(PaymentExceptionType.PAYMENT_PG_AMOUNT_MISMATCH);
+        }
+    }
+
+    private PaymentCallbackResp createSuccessResponse(Order order, Payment payment) {
+        return PaymentCallbackResp.builder()
+                .userId(order.getAccountId())
+                .paymentId(payment.getPaymentId())
+                .price(payment.getPrice())
+                .build();
     }
 }

--- a/src/main/java/ddog/daengleserver/domain/enums/PaymentExceptionType.java
+++ b/src/main/java/ddog/daengleserver/domain/enums/PaymentExceptionType.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 public enum PaymentExceptionType {
     PAYMENT_PG_INTEGRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "결제 정보 조회 중 에러 발생"),
     PAYMENT_PG_INCOMPLETE(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "미완료된 결제건"),
-    PAYMENT_PG_AMOUNT_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, 5003, "결제 금액 불일치");
+    PAYMENT_PG_AMOUNT_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, 5003, "결제 금액 불일치"),
+
+    PAYMENT_PG_SYSTEM_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, 5004, "포트원 API 응답 타임아웃");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/ddog/daengleserver/global/infra/resilience/Resilience4jConfig.java
+++ b/src/main/java/ddog/daengleserver/global/infra/resilience/Resilience4jConfig.java
@@ -1,0 +1,14 @@
+package ddog.daengleserver.global.infra.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Resilience4jConfig {
+
+    @Bean
+    public CircuitBreakerRegistry circuitBreakerRegistry() {
+        return CircuitBreakerRegistry.ofDefaults();
+    }
+}

--- a/src/main/java/ddog/daengleserver/presentation/payment/OrderController.java
+++ b/src/main/java/ddog/daengleserver/presentation/payment/OrderController.java
@@ -1,4 +1,4 @@
-package ddog.daengleserver.presentation;
+package ddog.daengleserver.presentation.payment;
 
 import ddog.daengleserver.global.auth.dto.PayloadDto;
 import ddog.daengleserver.global.common.CommonResponseEntity;
@@ -12,7 +12,7 @@ import static ddog.daengleserver.global.common.CommonResponseEntity.success;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/daengle")
+@RequestMapping("/api/v1/payment")
 public class OrderController {
 
     private final OrderUseCase orderUseCase;

--- a/src/main/java/ddog/daengleserver/presentation/payment/PaymentController.java
+++ b/src/main/java/ddog/daengleserver/presentation/payment/PaymentController.java
@@ -1,4 +1,4 @@
-package ddog.daengleserver.presentation;
+package ddog.daengleserver.presentation.payment;
 
 import ddog.daengleserver.global.common.CommonResponseEntity;
 import ddog.daengleserver.presentation.dto.request.PaymentCallbackReq;
@@ -14,12 +14,12 @@ import static ddog.daengleserver.global.common.CommonResponseEntity.success;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/daengle")
+@RequestMapping("/api/v1/payment")
 public class PaymentController {
 
     private final PaymentUseCase paymentUseCase;
 
-    @PostMapping("/payment")
+    @PostMapping("/validate")
     public CommonResponseEntity<PaymentCallbackResp> validationPayment(@RequestBody PaymentCallbackReq paymentCallbackReq) {
         return success(paymentUseCase.validationPayment(paymentCallbackReq));
     }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - https://hudi.blog/circuit-breaker-pattern/
    
> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 외부 API(포트원)에 의존하는 결제 프로세스 로직에 서킷브레이커 패턴을 적용
    - 타임아웃을 설정해 포트원 서버가 일정시간 내에 응답하지 않을 경우 요청 중단 후 웹서버에게 에러 응답

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 배포 후 테스트 필요

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : YES (resilience4j)
