### PR TITLE
[feat/daengle-52] 모놀로식 레포 & 단일 서버 환경에서의 외부 API(Kakao Solapi) 타임아웃 테스트 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
 
     // solapi-kakao
     implementation 'net.nurigo:sdk:4.3.2'
+
+    // Resilience4J
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
 
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // solapi-kakao
+    implementation 'net.nurigo:sdk:4.3.2'
 }
 
 test {

--- a/src/main/java/ddog/daengleserver/application/CareEstimateService.java
+++ b/src/main/java/ddog/daengleserver/application/CareEstimateService.java
@@ -46,6 +46,12 @@ public class CareEstimateService {
         return careEstimate.toUserCareEstimateDetail();
     }
 
+    @Transactional(readOnly = true)
+    public Vet getVetInfo(Long vetId){
+        Vet findVet = vetRepository.getVetByVetId(vetId);
+        return findVet;
+    }
+
     @Transactional
     public void createVetCareEstimate(VetCareEstimateReq request, Long accountId) {
         CareEstimate careEstimate = careEstimateRepository.getByCareEstimateId(request.getId());

--- a/src/main/java/ddog/daengleserver/application/KakaoNotificationService.java
+++ b/src/main/java/ddog/daengleserver/application/KakaoNotificationService.java
@@ -9,9 +9,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.concurrent.*;
 
 @Service
 public class KakaoNotificationService {
+    private static final Logger logger = LoggerFactory.getLogger(KakaoNotificationService.class);
+
     private final DefaultMessageService messageService;
 
     @Value("${kakao.pfId}")
@@ -25,27 +31,63 @@ public class KakaoNotificationService {
                                     @Value("${kakao.domain}") String kakaoDomain) {
         this.messageService = NurigoApp.INSTANCE.initialize(kakaoApiKey, kakaoApiSecretKey, kakaoDomain);
     }
+    private void executeNotification(String userName, String userPhoneNumber, String template) {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Void> future = executor.submit(() -> {
+            simulateDelay(); // 10초 지연 발생
+            sendKakaoMessage(userName, userPhoneNumber, template);
+            return null;
+        });
 
-    public void sendOneTalk(String userName, String userPhoneNumber, String template) {
+        try {
+            future.get(5, TimeUnit.SECONDS); // 타임아웃 5초 설정 => 5초 이상의 처리 시간 시, 예외처리
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Timeout: 알림톡 전송 요청이 5초를 초과했습니다.");
+        } catch (Exception e) {
+            throw new RuntimeException("알림톡 전송 중 오류 발생", e);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private void sendKakaoMessage(String userName, String userPhoneNumber, String template) {
         KakaoOption kakaoOption = new KakaoOption();
         kakaoOption.setDisableSms(true);
-
         kakaoOption.setPfId(kakaoPfid);
         kakaoOption.setTemplateId(template);
 
         HashMap<String, String> variables = new HashMap<>();
         variables.put("#{사용자}", userName);
-
         kakaoOption.setVariables(variables);
 
-        Message messageTosend = new Message();
-        messageTosend.setFrom(kakaoFrom);
-        messageTosend.setTo(userPhoneNumber);
+        Message messageToSend = new Message();
+        messageToSend.setFrom(kakaoFrom);
+        messageToSend.setTo(userPhoneNumber);
+        messageToSend.setKakaoOptions(kakaoOption);
 
-        messageTosend.setKakaoOptions(kakaoOption);
+        this.messageService.sendOne(new SingleMessageSendingRequest(messageToSend));
+    }
 
-        this.messageService.sendOne(
-                new SingleMessageSendingRequest(messageTosend)
-        );
+    private void simulateDelay() {
+        try {
+            Thread.sleep(7000); // 10초 지연
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @CircuitBreaker(name = "kakaoNotificationService", fallbackMethod = "fallbackSendOneTalk")
+    public boolean sendOneTalk(String userName, String userPhoneNumber, String template) {
+        try {
+            executeNotification(userName, userPhoneNumber, template);
+            return true; // 성공 시 true 반환
+        } catch (Exception e) {
+            throw new RuntimeException("카카오 알림톡 전송 실패", e);
+        }
+    }
+
+    public boolean fallbackSendOneTalk(String userName, String userPhoneNumber, String template, Throwable throwable) {
+        logger.error("Fallback activated: 알림톡 전송 실패. 사용자: {}, 오류: {}", userName, throwable.getMessage());
+        return false;
     }
 }

--- a/src/main/java/ddog/daengleserver/application/KakaoNotificationService.java
+++ b/src/main/java/ddog/daengleserver/application/KakaoNotificationService.java
@@ -1,0 +1,51 @@
+package ddog.daengleserver.application;
+
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.KakaoOption;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+
+@Service
+public class KakaoNotificationService {
+    private final DefaultMessageService messageService;
+
+    @Value("${kakao.pfId}")
+    private String kakaoPfid;
+
+    @Value("${kakao.setFrom}")
+    private String kakaoFrom;
+
+    public KakaoNotificationService(@Value("${kakao.apiKey}") String kakaoApiKey,
+                                    @Value("${kakao.apiSecretKey}") String kakaoApiSecretKey,
+                                    @Value("${kakao.domain}") String kakaoDomain) {
+        this.messageService = NurigoApp.INSTANCE.initialize(kakaoApiKey, kakaoApiSecretKey, kakaoDomain);
+    }
+
+    public void sendOneTalk(String userName, String userPhoneNumber, String template) {
+        KakaoOption kakaoOption = new KakaoOption();
+        kakaoOption.setDisableSms(true);
+
+        kakaoOption.setPfId(kakaoPfid);
+        kakaoOption.setTemplateId(template);
+
+        HashMap<String, String> variables = new HashMap<>();
+        variables.put("#{사용자}", userName);
+
+        kakaoOption.setVariables(variables);
+
+        Message messageTosend = new Message();
+        messageTosend.setFrom(kakaoFrom);
+        messageTosend.setTo(userPhoneNumber);
+
+        messageTosend.setKakaoOptions(kakaoOption);
+
+        this.messageService.sendOne(
+                new SingleMessageSendingRequest(messageTosend)
+        );
+    }
+}

--- a/src/main/java/ddog/daengleserver/application/repository/VetRepository.java
+++ b/src/main/java/ddog/daengleserver/application/repository/VetRepository.java
@@ -8,4 +8,6 @@ public interface VetRepository {
 
     Vet getVetByAccountId(Long accountId);
 
+    Vet getVetByVetId(Long vetId);
+
 }

--- a/src/main/java/ddog/daengleserver/domain/account/Vet.java
+++ b/src/main/java/ddog/daengleserver/domain/account/Vet.java
@@ -18,4 +18,5 @@ public class Vet {
     private String vetImage;
     private String address;
     private String vetIntroduction;
+    private String phoneNumber;
 }

--- a/src/main/java/ddog/daengleserver/infrastructure/VetJpaRepository.java
+++ b/src/main/java/ddog/daengleserver/infrastructure/VetJpaRepository.java
@@ -10,4 +10,6 @@ public interface VetJpaRepository extends JpaRepository<VetJpaEntity, Long> {
     Optional<VetJpaEntity> findByAccountId(Long accountId);
 
     VetJpaEntity getByAccountId(Long accountId);
+
+    Optional<VetJpaEntity> findByVetId(Long vetId);
 }

--- a/src/main/java/ddog/daengleserver/infrastructure/VetRepositoryImpl.java
+++ b/src/main/java/ddog/daengleserver/infrastructure/VetRepositoryImpl.java
@@ -25,4 +25,9 @@ public class VetRepositoryImpl implements VetRepository {
         return vetJpaRepository.getByAccountId(accountId)
                 .toModel();
     }
+
+    @Override
+    public Vet getVetByVetId(Long vetId) {
+        return vetJpaRepository.findByVetId(vetId).get().toModel();
+    }
 }

--- a/src/main/java/ddog/daengleserver/infrastructure/po/VetJpaEntity.java
+++ b/src/main/java/ddog/daengleserver/infrastructure/po/VetJpaEntity.java
@@ -23,6 +23,7 @@ public class VetJpaEntity {
     private String vetImage;
     private String address;
     private String vetIntroduction;
+    private String phoneNumber;
 
     public static VetJpaEntity from(Vet vet) {
         return VetJpaEntity.builder()
@@ -33,6 +34,7 @@ public class VetJpaEntity {
                 .vetImage(vet.getVetImage())
                 .address(vet.getAddress())
                 .vetIntroduction(vet.getVetIntroduction())
+                .phoneNumber(vet.getPhoneNumber())
                 .build();
     }
 
@@ -45,6 +47,7 @@ public class VetJpaEntity {
                 .vetImage(vetImage)
                 .address(address)
                 .vetIntroduction(vetIntroduction)
+                .phoneNumber(phoneNumber)
                 .build();
     }
 }

--- a/src/main/java/ddog/daengleserver/presentation/NotificationController.java
+++ b/src/main/java/ddog/daengleserver/presentation/NotificationController.java
@@ -20,7 +20,7 @@ public class NotificationController {
 
     @PostMapping
     public void sendToUserNotification() {
-        Vet vetInfo = careEstimateService.getVetInfo(1L);
+        Vet vetInfo = careEstimateService.getVetInfo(3L);
         boolean isNotificationSend = kakaoNotificationService.sendOneTalk(vetInfo.getVetName(), vetInfo.getPhoneNumber(), environment.getProperty("templateId.CALL"));
         if (!isNotificationSend) {
             throw new RuntimeException("알림톡 전송 실패");

--- a/src/main/java/ddog/daengleserver/presentation/NotificationController.java
+++ b/src/main/java/ddog/daengleserver/presentation/NotificationController.java
@@ -1,0 +1,31 @@
+package ddog.daengleserver.presentation;
+
+import ddog.daengleserver.application.CareEstimateService;
+import ddog.daengleserver.application.KakaoNotificationService;
+import ddog.daengleserver.domain.account.Vet;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static ddog.daengleserver.global.common.CommonResponseEntity.success;
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
+public class NotificationController {
+    private final KakaoNotificationService kakaoNotificationService;
+    private final Environment environment;
+    private final CareEstimateService careEstimateService;
+
+    @PostMapping
+    public void sendToUserNotification() {
+        Vet vetInfo = careEstimateService.getVetInfo(1L);
+        boolean isNotificationSend = kakaoNotificationService.sendOneTalk(vetInfo.getVetName(), vetInfo.getPhoneNumber(), environment.getProperty("templateId.CALL"));
+        if (!isNotificationSend) {
+            throw new RuntimeException("알림톡 전송 실패");
+        } else {
+            success("알림톡 전송 성공");
+        }
+    }
+}

--- a/src/main/java/ddog/daengleserver/presentation/notification/NotificationController.java
+++ b/src/main/java/ddog/daengleserver/presentation/notification/NotificationController.java
@@ -1,4 +1,4 @@
-package ddog.daengleserver.presentation;
+package ddog.daengleserver.presentation.notification;
 
 import ddog.daengleserver.presentation.notify.dto.NotificationReq;
 import ddog.daengleserver.presentation.usecase.SseEmitterUsecase;

--- a/src/main/java/ddog/daengleserver/presentation/notification/WebNotificationController.java
+++ b/src/main/java/ddog/daengleserver/presentation/notification/WebNotificationController.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notification")
-public class NotificationController {
+public class WebNotificationController {
     private final SseEmitterUsecase sseEmitterUsecase;
     private static final String INIT = "{\"message\" : \"CONNECTED\"}";
 

--- a/src/test/java/ddog/daengleserver/notify/WebNotificationControllerTest.java
+++ b/src/test/java/ddog/daengleserver/notify/WebNotificationControllerTest.java
@@ -12,7 +12,7 @@ import reactor.core.publisher.Flux;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class NotificationControllerTest {
+public class WebNotificationControllerTest {
 
     @Autowired
     private WebTestClient webTestClient;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : X
    - [Notion-API] : X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 모놀로식 레포 & 단일 서버 환경에서의 외부 API(Kakao Solapi) 타임아웃 설정
    - 서킷브레이킹 패턴 활용

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : YES (resilience4j)
