### PR TITLE
[feat/daengle-55] 주문 요청 데이터 유효성 검사 로직 구현

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/payment/Order.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Order.java
@@ -33,6 +33,37 @@ public class Order {
     private String visitorPhoneNumber;
     private Payment payment;
 
+    public static void validateRecipientName(String username) {
+        if (username == null || username.length() < 2 || username.length() > 10) {
+            throw new IllegalArgumentException("Invalid username: must be 2-10 characters.");
+        }
+    }
+
+    public static void validatePhoneNumber(String phoneNumber) {
+        if (phoneNumber == null || !phoneNumber.matches("^010-\\d{4}-\\d{4}$")) {
+            throw new IllegalArgumentException("Invalid phone number: must follow format 010-0000-0000.");
+        }
+    }
+
+    public static void validateShopName(String shopName) {
+        if (shopName == null || !shopName.matches("^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9\\s]{0,19}$")) {
+            throw new IllegalArgumentException("Shop name must be 1-20 characters long and can contain Korean, " +
+                    "English letters, numbers, and spaces, but cannot start or end with a space.");
+        }
+    }
+
+    public static void validateSchedule(LocalDateTime schedule) {
+        if (schedule == null || schedule.isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Schedule cannot be in the past or NULL.");
+        }
+    }
+
+    public static void validatePrice(Long price) {
+        if (price == null || price <= 0) {
+            throw new IllegalArgumentException("Price must be a positive number.");
+        }
+    }
+
     public static Order createBy(Long accountId, PostOrderInfo postOrderInfo, Payment payment) {
         return Order.builder()
                 .serviceType(postOrderInfo.getServiceType())

--- a/daengle-payment-api/src/main/java/ddog/payment/application/OrderService.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/OrderService.java
@@ -1,10 +1,17 @@
 package ddog.payment.application;
 
+import ddog.domain.estimate.CareEstimate;
+import ddog.domain.estimate.EstimateStatus;
+import ddog.domain.estimate.GroomingEstimate;
 import ddog.domain.payment.Order;
 import ddog.domain.payment.dto.PostOrderInfo;
 import ddog.domain.payment.Payment;
 import ddog.domain.payment.enums.ServiceType;
 import ddog.payment.application.dto.response.PostOrderResp;
+import ddog.payment.application.exception.CareEstimateException;
+import ddog.payment.application.exception.CareEstimateExceptionType;
+import ddog.payment.application.exception.GroomingEstimateException;
+import ddog.payment.application.exception.GroomingEstimateExceptionType;
 import ddog.persistence.mysql.port.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,9 +24,13 @@ public class OrderService {
     private final OrderPersist orderPersist;
     private final PaymentPersist paymentPersist;
 
+    private final GroomingEstimatePersist groomingEstimatePersist;
+    private final CareEstimatePersist careEstimatePersist;
+
     @Transactional
     public PostOrderResp processOrder(Long accountId, PostOrderInfo postOrderInfo) {
         validateEstimate(postOrderInfo.getServiceType(), postOrderInfo.getEstimateId());
+        validatePostOrderInfoDataFormat(postOrderInfo);
 
         Payment paymentToSave = Payment.createTemporaryHistoryBy(accountId, postOrderInfo);
         Payment SavedPayment = paymentPersist.save(paymentToSave);
@@ -35,23 +46,38 @@ public class OrderService {
                 .build();
     }
 
-    //TODO Estimate 도메인에게 책임 위임하기, 확장성이 있는 유효성 검사 로직을 구현하기 (언제든 새로운 00견적 서비스가 추가될 수 있다)
+    //TODO 서비스 제공자(미용사/수의사) PK 유요한지 검증, Groomer || Vet 도메인 객체에게 역할 위임
+    private void validatePostOrderInfoDataFormat(PostOrderInfo postOrderInfo) {
+        Order.validateRecipientName(postOrderInfo.getRecipientName());
+        Order.validateShopName(postOrderInfo.getShopName());
+        Order.validateSchedule(postOrderInfo.getSchedule());
+        Order.validatePrice(postOrderInfo.getPrice());
+        Order.validatePhoneNumber(postOrderInfo.getCustomerPhoneNumber());
+        Order.validatePhoneNumber(postOrderInfo.getVisitorPhoneNumber());
+    }
+
+    //TODO Estimate 도메인에게 역할 위임하기, 확장성이 있는 유효성 검사 로직을 구현하기 (언제든 새로운 00견적 서비스가 추가될 수 있다)
     private void validateEstimate(ServiceType serviceType, Long estimateId) {
-    /*        switch (serviceType) {
-            case GROOMING:
-                if (groomingEstimatePersist.getByGroomingEstimateId(estimateId) == null) {
-                    throw new IllegalArgumentException("Invalid estimate ID for Grooming service.");
-                }
-                break;
+        if (serviceType.equals(ServiceType.GROOMING)) {
+            GroomingEstimate estimate = groomingEstimatePersist.findByEstimateId(estimateId)
+                    .orElseThrow(() -> new GroomingEstimateException(GroomingEstimateExceptionType.GROOMING_ESTIMATE_NOT_FOUND));
 
-            case CARE:
-                if (careEstimatePersist.getByCareEstimateId(estimateId) == null) {
-                    throw new IllegalArgumentException("Invalid estimate ID for Care service.");
-                }
-                break;
+            groomingEstimatePersist.updateStatusWithParentId(EstimateStatus.END, estimate.getParentId());
 
-            default:
-                throw new IllegalArgumentException("Unsupported service type: " + serviceType);
-        }*/
+            estimate.updateStatus(EstimateStatus.ON_RESERVATION);
+            groomingEstimatePersist.save(estimate);
+
+        } else if (serviceType.equals(ServiceType.CARE)) {
+            CareEstimate estimate = careEstimatePersist.findByEstimateId(estimateId)
+                    .orElseThrow(() -> new CareEstimateException(CareEstimateExceptionType.CARE_ESTIMATE_NOT_FOUND));
+
+            careEstimatePersist.updateStatusWithParentId(EstimateStatus.END, estimate.getParentId());
+
+            estimate.updateStatus(EstimateStatus.ON_RESERVATION);
+            careEstimatePersist.save(estimate);
+
+        } else {
+            throw new IllegalArgumentException("서비스 타입이 올바르지 않습니다.");
+        }
     }
 }

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/DeployCheckController.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/DeployCheckController.java
@@ -13,7 +13,7 @@ import java.time.format.DateTimeFormatter;
 public class DeployCheckController {
     private String deploymentTime;
 
-    // 애플리케이션 시작 시 배포 시간을 기록
+    // 애플리케이션 시작 시 배포 시간 기록
     @PostConstruct
     public void init() {
         LocalDateTime now = LocalDateTime.now();
@@ -23,9 +23,6 @@ public class DeployCheckController {
 
     @GetMapping("/test")
     public String test() {
-//        LocalDateTime now = LocalDateTime.now();
-//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-//        String formattedDate = now.format(formatter);
         return "Hello Daengle World - MULTI MODULE !!!! PAYMENT API !" +
                 " Made at: " + deploymentTime + "   CI/CD SUCCESS";
     }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 주문 요청 시 요청 데이터의 형식을 검사하는 로직을 구현했습니다
    - 해당 유효성 검사 로직 역할은 도메인 객체에게 위임했습니다

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 현재 견적 유효성 검사(PK)를 OrderService와 PaymentService에서 하고 있습니다.
    - 이 역할을 Esitimate 도메인 객체에게 위임하고 Service에서는 호출만 하는 방식으로 리펙터링해야합니다
    - 이를 통해 OrderService와 PaymentService는 Order, Payment, Esitimate 객체들의 협력하는 공간이 됩니다

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
