### PR TITLE
[feat/daengle-56] 리뷰 작성 데이터 유효성 검사 로직 구현

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
@@ -21,6 +21,30 @@ public class CareReview extends Review {
     private Long vetId;
     private List<CareKeywordReview> careKeywordReviewList;
 
+    public static void validateStarRating(Long starRating) {
+        if (starRating == null || starRating < 1 || starRating > 5) {
+            throw new IllegalArgumentException("Star rating must be between 1 and 5.");
+        }
+    }
+
+    public static void validateCareKeywordReviewList(List<CareKeywordReview> careKeywordReviewList) {
+        if (careKeywordReviewList == null || careKeywordReviewList.size() < 1 || careKeywordReviewList.size() > 3) {
+            throw new IllegalArgumentException("Care keyword review list must contain 1 to 3 items.");
+        }
+    }
+
+    public static void validateContent(String content) {
+        if (content != null && content.length() > 400) {
+            throw new IllegalArgumentException("Content must be 400 characters or less.");
+        }
+    }
+
+    public static void validateImageUrlList(List<String> imageUrlList) {
+        if (imageUrlList != null && imageUrlList.size() > 10) {
+            throw new IllegalArgumentException("Image URL list must contain 10 items or less.");
+        }
+    }
+
     public static CareReview createBy(Reservation reservation, PostCareReviewInfo postCareReviewInfo) {
         return CareReview.builder()
                 .reservationId(reservation.getReservationId())

--- a/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
@@ -22,6 +22,30 @@ public class GroomingReview extends Review {
     private Long groomerId;
     private List<GroomingKeywordReview> groomingKeywordReviewList;
 
+    public static void validateStarRating(Long starRating) {
+        if (starRating == null || starRating < 1 || starRating > 5) {
+            throw new IllegalArgumentException("Star rating must be between 1 and 5.");
+        }
+    }
+
+    public static void validateGroomingKeywordReviewList(List<GroomingKeywordReview> groomingKeywordReviewList) {
+        if (groomingKeywordReviewList == null || groomingKeywordReviewList.size() < 1 || groomingKeywordReviewList.size() > 3) {
+            throw new IllegalArgumentException("Grooming keyword review list must contain 1 to 3 items.");
+        }
+    }
+
+    public static void validateContent(String content) {
+        if (content != null && content.length() > 400) {
+            throw new IllegalArgumentException("Content must be 400 characters or less.");
+        }
+    }
+
+    public static void validateImageUrlList(List<String> imageUrlList) {
+        if (imageUrlList != null && imageUrlList.size() > 10) {
+            throw new IllegalArgumentException("Image URL list must contain 10 items or less.");
+        }
+    }
+
     public static GroomingReview createBy(Reservation reservation, PostGroomingReviewInfo postGroomingReviewInfo) {
         return GroomingReview.builder()
                 .reservationId(reservation.getReservationId())

--- a/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
@@ -38,6 +38,8 @@ public class CareReviewService {
         Reservation reservation = reservationPersist.findBy(postCareReviewInfo.getReservationId()).orElseThrow(()
                 -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
 
+        validatePostCareReviewInfo(postCareReviewInfo);
+
         CareReview careReviewToSave = CareReview.createBy(reservation, postCareReviewInfo);
         CareReview savedCareReview = careReviewPersist.save(careReviewToSave);
 
@@ -116,5 +118,12 @@ public class CareReviewService {
                         .content(careReview.getContent())
                         .build()
         ).toList();
+    }
+
+    private void validatePostCareReviewInfo(PostCareReviewInfo postCareReviewInfo) {
+        CareReview.validateStarRating(postCareReviewInfo.getStarRating());
+        CareReview.validateCareKeywordReviewList(postCareReviewInfo.getCareKeywordReviewList());
+        CareReview.validateContent(postCareReviewInfo.getContent());
+        CareReview.validateImageUrlList(postCareReviewInfo.getImageUrlList());
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
@@ -38,7 +38,7 @@ public class CareReviewService {
         Reservation reservation = reservationPersist.findBy(postCareReviewInfo.getReservationId()).orElseThrow(()
                 -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
 
-        validatePostCareReviewInfo(postCareReviewInfo);
+        validatePostCareReviewInfoDataFormat(postCareReviewInfo);
 
         CareReview careReviewToSave = CareReview.createBy(reservation, postCareReviewInfo);
         CareReview savedCareReview = careReviewPersist.save(careReviewToSave);
@@ -55,6 +55,8 @@ public class CareReviewService {
     public ReviewResp modifyReview(Long reviewId, ModifyCareReviewInfo modifyCareReviewInfo) {
         CareReview savedCareReview = careReviewPersist.findBy(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
+
+        validateModifyCareReviewInfoDataFormat(modifyCareReviewInfo);
 
         CareReview modifiedReview = CareReview.modifyBy(savedCareReview, modifyCareReviewInfo);
         CareReview updatedCareReview = careReviewPersist.save(modifiedReview);
@@ -120,10 +122,17 @@ public class CareReviewService {
         ).toList();
     }
 
-    private void validatePostCareReviewInfo(PostCareReviewInfo postCareReviewInfo) {
+    private void validatePostCareReviewInfoDataFormat(PostCareReviewInfo postCareReviewInfo) {
         CareReview.validateStarRating(postCareReviewInfo.getStarRating());
         CareReview.validateCareKeywordReviewList(postCareReviewInfo.getCareKeywordReviewList());
         CareReview.validateContent(postCareReviewInfo.getContent());
         CareReview.validateImageUrlList(postCareReviewInfo.getImageUrlList());
+    }
+
+    private void validateModifyCareReviewInfoDataFormat(ModifyCareReviewInfo modifyCareReviewInfo) {
+        CareReview.validateStarRating(modifyCareReviewInfo.getStarRating());
+        CareReview.validateCareKeywordReviewList(modifyCareReviewInfo.getCareKeywordReviewList());
+        CareReview.validateContent(modifyCareReviewInfo.getContent());
+        CareReview.validateImageUrlList(modifyCareReviewInfo.getImageUrlList());
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
@@ -40,6 +40,8 @@ public class GroomingReviewService {
         Reservation reservation = reservationPersist.findBy(postGroomingReviewInfo.getReservationId()).orElseThrow(()
                 -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
 
+        validatePostGroomingReviewInfoDataFormat(postGroomingReviewInfo);
+
         GroomingReview groomingReviewToSave = GroomingReview.createBy(reservation, postGroomingReviewInfo);
         GroomingReview SavedGroomingReview = groomingReviewPersist.save(groomingReviewToSave);
 
@@ -55,6 +57,8 @@ public class GroomingReviewService {
     public ReviewResp modifyReview(Long reviewId, ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
         GroomingReview savedGroomingReview = groomingReviewPersist.findBy(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
+
+        validateModifyGroomingReviewInfoDataFormat(modifyGroomingReviewInfo);
 
         GroomingReview modifiedReview = GroomingReview.modifyBy(savedGroomingReview, modifyGroomingReviewInfo);
         GroomingReview updatedGroomingReview = groomingReviewPersist.save(modifiedReview);
@@ -120,5 +124,19 @@ public class GroomingReviewService {
                         .content(groomingReview.getContent())
                         .build()
         ).toList();
+    }
+
+    private void validatePostGroomingReviewInfoDataFormat(PostGroomingReviewInfo postGroomingReviewInfo) {
+        GroomingReview.validateStarRating(postGroomingReviewInfo.getStarRating());
+        GroomingReview.validateGroomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList());
+        GroomingReview.validateContent(postGroomingReviewInfo.getContent());
+        GroomingReview.validateImageUrlList(postGroomingReviewInfo.getImageUrlList());
+    }
+
+    private void validateModifyGroomingReviewInfoDataFormat(ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
+        GroomingReview.validateStarRating(modifyGroomingReviewInfo.getStarRating());
+        GroomingReview.validateGroomingKeywordReviewList(modifyGroomingReviewInfo.getGroomingKeywordReviewList());
+        GroomingReview.validateContent(modifyGroomingReviewInfo.getContent());
+        GroomingReview.validateImageUrlList(modifyGroomingReviewInfo.getImageUrlList());
     }
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : 
    - [Notion-API] : 

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 리뷰 작성 요청 데이터의 형식을 검사하는 로직을 구현했습니다
    - 해당 유효성 검사 로직 역할은 도메인 객체에게 위임했습니다

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
