### PR TITLE
[refactoring/daengle-58] 코드 컨벤션 통일 (정적 팩터리 메서드, findBy)

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
@@ -8,7 +8,5 @@ public interface GroomerPersist {
 
     Optional<Groomer> findByAccountId(Long accountId);
 
-    Optional<Groomer> findBy(Long id);
-
     void save(Groomer newGroomer);
 }

--- a/daengle-domain/src/main/java/ddog/domain/payment/Order.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Order.java
@@ -1,6 +1,5 @@
 package ddog.domain.payment;
 
-import ddog.domain.payment.dto.PostOrderInfo;
 import ddog.domain.payment.enums.ServiceType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -62,25 +61,5 @@ public class Order {
         if (price == null || price <= 0) {
             throw new IllegalArgumentException("Price must be a positive number.");
         }
-    }
-
-    public static Order createBy(Long accountId, PostOrderInfo postOrderInfo, Payment payment) {
-        return Order.builder()
-                .serviceType(postOrderInfo.getServiceType())
-                .price(postOrderInfo.getPrice())
-                .estimateId(postOrderInfo.getEstimateId())
-                .orderUid(String.valueOf(UUID.randomUUID()))
-                .accountId(accountId)
-                .customerName(postOrderInfo.getCustomerName())
-                .recipientId(postOrderInfo.getRecipientId())
-                .recipientName(postOrderInfo.getRecipientName())
-                .shopName(postOrderInfo.getShopName())
-                .orderDate(LocalDateTime.now())
-                .schedule(postOrderInfo.getSchedule())
-                .visitorName(postOrderInfo.getVisitorName())
-                .customerPhoneNumber(postOrderInfo.getCustomerPhoneNumber())
-                .visitorPhoneNumber(postOrderInfo.getVisitorPhoneNumber())
-                .payment(payment)
-                .build();
     }
 }

--- a/daengle-domain/src/main/java/ddog/domain/payment/Payment.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Payment.java
@@ -1,6 +1,5 @@
 package ddog.domain.payment;
 
-import ddog.domain.payment.dto.PostOrderInfo;
 import ddog.domain.payment.enums.PaymentStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,17 +24,6 @@ public class Payment {
     private String paymentUid;
 
     public static final String PAYMENT_SUCCESS_STATUS = "paid";
-
-    public static Payment createTemporaryHistoryBy(Long accountId, PostOrderInfo postOrderInfo) {
-        return Payment.builder()
-                .paymentId(null)
-                .payerId(accountId)
-                .price(postOrderInfo.getPrice())
-                .status(PaymentStatus.READY)
-                .paymentDate(LocalDateTime.now())
-                .paymentUid(null)
-                .build();
-    }
 
     //결제 완료 확인
     public boolean checkIncompleteBy(String paymentStatus) {

--- a/daengle-domain/src/main/java/ddog/domain/payment/port/OrderPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/port/OrderPersist.java
@@ -6,6 +6,6 @@ import java.util.Optional;
 
 public interface OrderPersist {
     Order save(Order order);
-    Optional<Order> findBy(String orderUid);
+    Optional<Order> findByOrderUid(String orderUid);
     void delete(Order order);
 }

--- a/daengle-domain/src/main/java/ddog/domain/payment/port/ReservationPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/port/ReservationPersist.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 
 public interface ReservationPersist {
     Reservation save(Reservation reservation);
-    Optional<Reservation> findBy(Long reservationId);
+    Optional<Reservation> findByReservationId(Long reservationId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
@@ -1,8 +1,6 @@
 package ddog.domain.review;
 
 import ddog.domain.payment.Reservation;
-import ddog.domain.review.dto.ModifyCareReviewInfo;
-import ddog.domain.review.dto.PostCareReviewInfo;
 import ddog.domain.review.enums.CareKeywordReview;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,59 +19,9 @@ public class CareReview extends Review {
     private Long vetId;
     private List<CareKeywordReview> careKeywordReviewList;
 
-    public static void validateStarRating(Long starRating) {
-        if (starRating == null || starRating < 1 || starRating > 5) {
-            throw new IllegalArgumentException("Star rating must be between 1 and 5.");
-        }
-    }
-
     public static void validateCareKeywordReviewList(List<CareKeywordReview> careKeywordReviewList) {
-        if (careKeywordReviewList == null || careKeywordReviewList.size() < 1 || careKeywordReviewList.size() > 3) {
+        if (careKeywordReviewList == null || careKeywordReviewList.isEmpty() || careKeywordReviewList.size() > 3) {
             throw new IllegalArgumentException("Care keyword review list must contain 1 to 3 items.");
         }
-    }
-
-    public static void validateContent(String content) {
-        if (content != null && content.length() > 400) {
-            throw new IllegalArgumentException("Content must be 400 characters or less.");
-        }
-    }
-
-    public static void validateImageUrlList(List<String> imageUrlList) {
-        if (imageUrlList != null && imageUrlList.size() > 10) {
-            throw new IllegalArgumentException("Image URL list must contain 10 items or less.");
-        }
-    }
-
-    public static CareReview createBy(Reservation reservation, PostCareReviewInfo postCareReviewInfo) {
-        return CareReview.builder()
-                .reservationId(reservation.getReservationId())
-                .reviewerId(reservation.getCustomerId())
-                .revieweeName(reservation.getRecipientName())
-                .shopName(reservation.getShopName())
-                .starRating(postCareReviewInfo.getStarRating())
-                .content(postCareReviewInfo.getContent())
-                .createTime(LocalDateTime.now())
-                .imageUrlList(postCareReviewInfo.getImageUrlList())
-                .vetId(reservation.getRecipientId())
-                .careKeywordReviewList(postCareReviewInfo.getCareKeywordReviewList())
-                .build();
-    }
-
-    public static CareReview modifyBy(CareReview careReview, ModifyCareReviewInfo modifyCareReviewInfo) {
-        return CareReview.builder()
-                .careReviewId(careReview.getCareReviewId())
-                .reservationId(careReview.getReservationId())
-                .reviewerId(careReview.getReviewerId())
-                .vetId(careReview.getVetId())
-                .revieweeName(careReview.getRevieweeName())
-                .shopName(careReview.getShopName())
-                .starRating(modifyCareReviewInfo.getStarRating())
-                .content(modifyCareReviewInfo.getContent())
-                .createTime(careReview.getCreateTime())
-                .modifiedTime(LocalDateTime.now())
-                .imageUrlList(modifyCareReviewInfo.getImageUrlList())
-                .careKeywordReviewList(modifyCareReviewInfo.getCareKeywordReviewList())
-                .build();
     }
 }

--- a/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
@@ -1,11 +1,7 @@
 package ddog.domain.review;
 
-import ddog.domain.payment.Reservation;
-import ddog.domain.review.dto.ModifyGroomingReviewInfo;
-import ddog.domain.review.dto.PostGroomingReviewInfo;
 import ddog.domain.review.enums.GroomingKeywordReview;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -22,59 +18,9 @@ public class GroomingReview extends Review {
     private Long groomerId;
     private List<GroomingKeywordReview> groomingKeywordReviewList;
 
-    public static void validateStarRating(Long starRating) {
-        if (starRating == null || starRating < 1 || starRating > 5) {
-            throw new IllegalArgumentException("Star rating must be between 1 and 5.");
-        }
-    }
-
     public static void validateGroomingKeywordReviewList(List<GroomingKeywordReview> groomingKeywordReviewList) {
-        if (groomingKeywordReviewList == null || groomingKeywordReviewList.size() < 1 || groomingKeywordReviewList.size() > 3) {
+        if (groomingKeywordReviewList == null || groomingKeywordReviewList.isEmpty() || groomingKeywordReviewList.size() > 3) {
             throw new IllegalArgumentException("Grooming keyword review list must contain 1 to 3 items.");
         }
-    }
-
-    public static void validateContent(String content) {
-        if (content != null && content.length() > 400) {
-            throw new IllegalArgumentException("Content must be 400 characters or less.");
-        }
-    }
-
-    public static void validateImageUrlList(List<String> imageUrlList) {
-        if (imageUrlList != null && imageUrlList.size() > 10) {
-            throw new IllegalArgumentException("Image URL list must contain 10 items or less.");
-        }
-    }
-
-    public static GroomingReview createBy(Reservation reservation, PostGroomingReviewInfo postGroomingReviewInfo) {
-        return GroomingReview.builder()
-                .reservationId(reservation.getReservationId())
-                .reviewerId(reservation.getCustomerId())
-                .groomerId(reservation.getRecipientId())
-                .revieweeName(reservation.getRecipientName())
-                .shopName(reservation.getShopName())
-                .starRating(postGroomingReviewInfo.getStarRating())
-                .content(postGroomingReviewInfo.getContent())
-                .createTime(LocalDateTime.now())
-                .imageUrlList(postGroomingReviewInfo.getImageUrlList())
-                .groomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList())
-                .build();
-    }
-
-    public static GroomingReview modifyBy(GroomingReview groomingReview, ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
-        return GroomingReview.builder()
-                .groomingReviewId(groomingReview.getGroomingReviewId())
-                .reservationId(groomingReview.getReservationId())
-                .reviewerId(groomingReview.getReviewerId())
-                .groomerId(groomingReview.getGroomerId())
-                .revieweeName(groomingReview.getRevieweeName())
-                .shopName(groomingReview.getShopName())
-                .starRating(modifyGroomingReviewInfo.getStarRating())
-                .content(modifyGroomingReviewInfo.getContent())
-                .createTime(groomingReview.getCreateTime())
-                .modifiedTime(LocalDateTime.now())
-                .imageUrlList(modifyGroomingReviewInfo.getImageUrlList())
-                .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
-                .build();
     }
 }

--- a/daengle-domain/src/main/java/ddog/domain/review/Review.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/Review.java
@@ -23,4 +23,22 @@ public abstract class Review {
     private LocalDateTime createTime;
     private LocalDateTime modifiedTime;
     private List<String> imageUrlList;
+
+    public static void validateStarRating(Long starRating) {
+        if (starRating == null || starRating < 1 || starRating > 5) {
+            throw new IllegalArgumentException("Star rating must be between 1 and 5.");
+        }
+    }
+
+    public static void validateContent(String content) {
+        if (content != null && content.length() > 400) {
+            throw new IllegalArgumentException("Content must be 400 characters or less.");
+        }
+    }
+
+    public static void validateImageUrlList(List<String> imageUrlList) {
+        if (imageUrlList != null && imageUrlList.size() > 10) {
+            throw new IllegalArgumentException("Image URL list must contain 10 items or less.");
+        }
+    }
 }

--- a/daengle-domain/src/main/java/ddog/domain/review/port/CareReviewPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/port/CareReviewPersist.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.Optional;
 
 public interface CareReviewPersist {
-    Optional<CareReview> findBy(Long careReviewId);
+    Optional<CareReview> findByReviewId(Long careReviewId);
     CareReview save(CareReview careReview);
     void delete(CareReview careReview);
     Page<CareReview> findByReviewerId(Long userId, Pageable pageable);

--- a/daengle-domain/src/main/java/ddog/domain/review/port/GroomingReviewPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/port/GroomingReviewPersist.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.Optional;
 
 public interface GroomingReviewPersist {
-    Optional<GroomingReview> findBy(Long groomingId);
+    Optional<GroomingReview> findByGroomingId(Long groomingId);
     GroomingReview save(GroomingReview groomingReview);
     void delete(GroomingReview groomingReview);
     Page<GroomingReview> findByReviewerId(Long userId, Pageable pageable);

--- a/daengle-domain/src/main/java/ddog/domain/user/port/UserPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/user/port/UserPersist.java
@@ -9,7 +9,5 @@ public interface UserPersist {
 
     Optional<User> findByAccountId(Long accountId);
 
-    Optional<User> findBy(Long id);
-
     Boolean hasNickname(String nickname);
 }

--- a/daengle-domain/src/main/java/ddog/domain/vet/port/VetPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/port/VetPersist.java
@@ -8,5 +8,4 @@ public interface VetPersist {
     Optional<Vet> findByAccountId(Long accountId);
 
     void save(Vet vet);
-    Optional<Vet> findBy(Long id);
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/ReviewService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/ReviewService.java
@@ -24,7 +24,7 @@ public class ReviewService {
     private final GroomerPersist groomerPersist;
 
     public List<ReviewSummaryResp> findReviewList(Long accountId, int page, int size) {
-        Groomer savedGroomer = groomerPersist.findBy(accountId)
+        Groomer savedGroomer = groomerPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(page, size);

--- a/daengle-payment-api/src/main/java/ddog/payment/application/OrderService.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/OrderService.java
@@ -6,7 +6,9 @@ import ddog.domain.estimate.GroomingEstimate;
 import ddog.domain.estimate.port.CareEstimatePersist;
 import ddog.domain.estimate.port.GroomingEstimatePersist;
 import ddog.domain.payment.Order;
-import ddog.domain.payment.dto.PostOrderInfo;
+import ddog.payment.application.mapper.OrderMapper;
+import ddog.payment.application.mapper.PaymentMapper;
+import ddog.payment.presentation.dto.PostOrderInfo;
 import ddog.domain.payment.Payment;
 import ddog.domain.payment.enums.ServiceType;
 import ddog.domain.payment.port.OrderPersist;
@@ -35,10 +37,10 @@ public class OrderService {
         validateEstimate(postOrderInfo.getServiceType(), postOrderInfo.getEstimateId());
         validatePostOrderInfoDataFormat(postOrderInfo);
 
-        Payment paymentToSave = Payment.createTemporaryHistoryBy(accountId, postOrderInfo);
+        Payment paymentToSave = PaymentMapper.createTemporaryHistoryBy(accountId, postOrderInfo);
         Payment SavedPayment = paymentPersist.save(paymentToSave);
 
-        Order orderToSave = Order.createBy(accountId, postOrderInfo, SavedPayment);
+        Order orderToSave = OrderMapper.createBy(accountId, postOrderInfo, SavedPayment);
         Order savedOrder = orderPersist.save(orderToSave);
 
         return PostOrderResp.builder()

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/OrderMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/OrderMapper.java
@@ -1,0 +1,31 @@
+package ddog.payment.application.mapper;
+
+import ddog.domain.payment.Order;
+import ddog.domain.payment.Payment;
+import ddog.payment.presentation.dto.PostOrderInfo;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class OrderMapper {
+
+    public static Order createBy(Long accountId, PostOrderInfo postOrderInfo, Payment payment) {
+        return Order.builder()
+                .serviceType(postOrderInfo.getServiceType())
+                .price(postOrderInfo.getPrice())
+                .estimateId(postOrderInfo.getEstimateId())
+                .orderUid(String.valueOf(UUID.randomUUID()))
+                .accountId(accountId)
+                .customerName(postOrderInfo.getCustomerName())
+                .recipientId(postOrderInfo.getRecipientId())
+                .recipientName(postOrderInfo.getRecipientName())
+                .shopName(postOrderInfo.getShopName())
+                .orderDate(LocalDateTime.now())
+                .schedule(postOrderInfo.getSchedule())
+                .visitorName(postOrderInfo.getVisitorName())
+                .customerPhoneNumber(postOrderInfo.getCustomerPhoneNumber())
+                .visitorPhoneNumber(postOrderInfo.getVisitorPhoneNumber())
+                .payment(payment)
+                .build();
+    }
+}

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/PaymentMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/PaymentMapper.java
@@ -1,0 +1,21 @@
+package ddog.payment.application.mapper;
+
+import ddog.domain.payment.Payment;
+import ddog.domain.payment.enums.PaymentStatus;
+import ddog.payment.presentation.dto.PostOrderInfo;
+
+import java.time.LocalDateTime;
+
+public class PaymentMapper {
+
+    public static Payment createTemporaryHistoryBy(Long accountId, PostOrderInfo postOrderInfo) {
+        return Payment.builder()
+                .paymentId(null)
+                .payerId(accountId)
+                .price(postOrderInfo.getPrice())
+                .status(PaymentStatus.READY)
+                .paymentDate(LocalDateTime.now())
+                .paymentUid(null)
+                .build();
+    }
+}

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/ReservationMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/ReservationMapper.java
@@ -1,0 +1,27 @@
+package ddog.payment.application.mapper;
+
+import ddog.domain.payment.Order;
+import ddog.domain.payment.Payment;
+import ddog.domain.payment.Reservation;
+import ddog.domain.payment.enums.ReservationStatus;
+
+public class ReservationMapper {
+
+    public static Reservation createBy(Order order, Payment payment) {
+        return Reservation.builder()
+                .estimateId(order.getEstimateId())
+                .serviceType(order.getServiceType())
+                .reservationStatus(ReservationStatus.DEPOSIT_PAID)
+                .recipientId(order.getRecipientId())  //수의사 or 병원 PK
+                .recipientName(order.getRecipientName())
+                .shopName(order.getShopName())
+                .schedule(order.getSchedule())
+                .deposit(order.getPrice())
+                .customerId(order.getAccountId())
+                .customerPhoneNumber(order.getCustomerPhoneNumber())
+                .visitorName(order.getVisitorName())
+                .visitorPhoneNumber(order.getVisitorPhoneNumber())
+                .paymentId(payment.getPaymentId())
+                .build();
+    }
+}

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/OrderController.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/OrderController.java
@@ -2,7 +2,7 @@ package ddog.payment.presentation;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
-import ddog.domain.payment.dto.PostOrderInfo;
+import ddog.payment.presentation.dto.PostOrderInfo;
 import ddog.payment.application.OrderService;
 import ddog.payment.application.dto.response.PostOrderResp;
 

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
@@ -1,4 +1,4 @@
-package ddog.domain.payment.dto;
+package ddog.payment.presentation.dto;
 
 import ddog.domain.payment.enums.ServiceType;
 import lombok.Builder;

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareReviewRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareReviewRepository.java
@@ -18,7 +18,7 @@ public class CareReviewRepository implements CareReviewPersist {
     private final CareReviewJpaRepository careReviewJpaRepository;
 
     @Override
-    public Optional<CareReview> findBy(Long careReviewId) {
+    public Optional<CareReview> findByReviewId(Long careReviewId) {
         return careReviewJpaRepository.findById(careReviewId).map(CareReviewJpaEntity::toModel);
     }
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerRepository.java
@@ -22,11 +22,6 @@ public class GroomerRepository implements GroomerPersist {
     }
 
     @Override
-    public Optional<Groomer> findBy(Long accountId) {
-        return groomerJpaRepository.findByAccountId(accountId).map(GroomerJpaEntity::toModel);
-    }
-
-    @Override
     public void save(Groomer newGroomer) {
         groomerJpaRepository.save(GroomerJpaEntity.from(newGroomer));
     }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingReviewRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingReviewRepository.java
@@ -18,7 +18,7 @@ public class GroomingReviewRepository implements GroomingReviewPersist {
     private final GroomingReviewJpaRepository groomingReviewJpaRepository;
 
     @Override
-    public Optional<GroomingReview> findBy(Long groomingId) {
+    public Optional<GroomingReview> findByGroomingId(Long groomingId) {
         return groomingReviewJpaRepository.findById(groomingId).map(GroomingReviewJpaEntity::toModel);
     }
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/OrderRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/OrderRepository.java
@@ -22,7 +22,7 @@ public class OrderRepository implements OrderPersist {
     }
 
     @Override
-    public Optional<Order> findBy(String orderUid) {
+    public Optional<Order> findByOrderUid(String orderUid) {
         return orderJpaRepository.findByOrderUid(orderUid).map(OrderJpaEntity::toModel);
     }
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/ReservationRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/ReservationRepository.java
@@ -22,7 +22,7 @@ public class ReservationRepository implements ReservationPersist {
     }
 
     @Override
-    public Optional<Reservation> findBy(Long reservationId) {
+    public Optional<Reservation> findByReservationId(Long reservationId) {
         return reservationJpaRepository.findByReservationId(reservationId).map(ReservationJpaEntity::toModel);
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/UserRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/UserRepository.java
@@ -27,11 +27,6 @@ public class UserRepository implements UserPersist {
     }
 
     @Override
-    public Optional<User> findBy(Long accountId ) {
-        return userJpaRepository.findByAccountId(accountId).map(UserJpaEntity::toModel);
-    }
-
-    @Override
     public Boolean hasNickname(String nickname) {
         return userJpaRepository.existsByNickname(nickname);
     }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetRepository.java
@@ -25,9 +25,4 @@ public class VetRepository implements VetPersist {
     public void save(Vet vet) {
         vetJpaRepository.save(VetJpaEntity.from(vet));
     }
-
-    @Override
-    public Optional<Vet> findBy(Long accountId) {
-        return vetJpaRepository.findByAccountId(accountId).map(VetJpaEntity::toModel);
-    }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
@@ -2,8 +2,9 @@ package ddog.user.application;
 
 import ddog.domain.payment.Reservation;
 import ddog.domain.review.CareReview;
-import ddog.domain.review.dto.ModifyCareReviewInfo;
-import ddog.domain.review.dto.PostCareReviewInfo;
+import ddog.user.application.mapper.CareReviewMapper;
+import ddog.user.presentation.review.dto.ModifyCareReviewInfo;
+import ddog.user.presentation.review.dto.PostCareReviewInfo;
 import ddog.domain.user.User;
 import ddog.domain.vet.Vet;
 import ddog.domain.review.port.CareReviewPersist;
@@ -36,12 +37,12 @@ public class CareReviewService {
     private final UserPersist userPersist;
 
     public ReviewResp postReview(PostCareReviewInfo postCareReviewInfo) {
-        Reservation reservation = reservationPersist.findBy(postCareReviewInfo.getReservationId()).orElseThrow(()
+        Reservation reservation = reservationPersist.findByReservationId(postCareReviewInfo.getReservationId()).orElseThrow(()
                 -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
 
         validatePostCareReviewInfoDataFormat(postCareReviewInfo);
 
-        CareReview careReviewToSave = CareReview.createBy(reservation, postCareReviewInfo);
+        CareReview careReviewToSave = CareReviewMapper.createBy(reservation, postCareReviewInfo);
         CareReview savedCareReview = careReviewPersist.save(careReviewToSave);
 
         //TODO 댕글미터 계산해서 영속
@@ -54,12 +55,12 @@ public class CareReviewService {
     }
 
     public ReviewResp modifyReview(Long reviewId, ModifyCareReviewInfo modifyCareReviewInfo) {
-        CareReview savedCareReview = careReviewPersist.findBy(reviewId)
+        CareReview savedCareReview = careReviewPersist.findByReviewId(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
 
         validateModifyCareReviewInfoDataFormat(modifyCareReviewInfo);
 
-        CareReview modifiedReview = CareReview.modifyBy(savedCareReview, modifyCareReviewInfo);
+        CareReview modifiedReview = CareReviewMapper.modifyBy(savedCareReview, modifyCareReviewInfo);
         CareReview updatedCareReview = careReviewPersist.save(modifiedReview);
 
         //TODO 댕글미터 재계산해서 영속
@@ -71,8 +72,8 @@ public class CareReviewService {
                 .build();
     }
 
-    public CareReviewDetailResp getReview(Long reviewId) {
-        CareReview savedCareReview = careReviewPersist.findBy(reviewId)
+    public CareReviewDetailResp findReview(Long reviewId) {
+        CareReview savedCareReview = careReviewPersist.findByReviewId(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
 
         return CareReviewDetailResp.builder()
@@ -88,7 +89,7 @@ public class CareReviewService {
     }
 
     public ReviewResp deleteReview(Long reviewId) {
-        CareReview savedCareReview = careReviewPersist.findBy(reviewId)
+        CareReview savedCareReview = careReviewPersist.findByReviewId(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
 
         careReviewPersist.delete(savedCareReview);
@@ -101,7 +102,7 @@ public class CareReviewService {
     }
 
     public List<CareReviewSummaryResp> findMyReviewList(Long accountId, int page, int size) {
-        User savedUser = userPersist.findBy(accountId)
+        User savedUser = userPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(page, size);
@@ -121,7 +122,7 @@ public class CareReviewService {
     }
 
     public List<CareReviewSummaryResp> findVetReviewList(Long vetId, int page, int size) {
-        Vet savedVet = vetPersist.findBy(vetId)
+        Vet savedVet = vetPersist.findByAccountId(vetId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEWWEE_NOT_FOUNT));
 
         Pageable pageable = PageRequest.of(page, size);

--- a/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
@@ -3,8 +3,8 @@ package ddog.user.application;
 import ddog.domain.groomer.Groomer;
 import ddog.domain.payment.Reservation;
 import ddog.domain.review.GroomingReview;
-import ddog.domain.review.dto.ModifyGroomingReviewInfo;
-import ddog.domain.review.dto.PostGroomingReviewInfo;
+import ddog.user.presentation.review.dto.ModifyGroomingReviewInfo;
+import ddog.user.presentation.review.dto.PostGroomingReviewInfo;
 import ddog.domain.user.User;
 import ddog.domain.groomer.port.GroomerPersist;
 import ddog.domain.review.port.GroomingReviewPersist;
@@ -16,6 +16,7 @@ import ddog.user.application.exception.estimate.ReservationExceptionType;
 import ddog.user.application.exception.ReviewException;
 import ddog.user.application.exception.ReviewExceptionType;
 import ddog.domain.user.port.UserPersist;
+import ddog.user.application.mapper.GroomingReviewMapper;
 import ddog.user.presentation.review.dto.GroomingReviewDetailResp;
 import ddog.user.presentation.review.dto.GroomingReviewSummaryResp;
 import ddog.user.presentation.review.dto.ReviewResp;
@@ -37,12 +38,12 @@ public class GroomingReviewService {
     private final UserPersist userPersist;
 
     public ReviewResp postReview(PostGroomingReviewInfo postGroomingReviewInfo) {
-        Reservation reservation = reservationPersist.findBy(postGroomingReviewInfo.getReservationId()).orElseThrow(()
+        Reservation reservation = reservationPersist.findByReservationId(postGroomingReviewInfo.getReservationId()).orElseThrow(()
                 -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
 
         validatePostGroomingReviewInfoDataFormat(postGroomingReviewInfo);
 
-        GroomingReview groomingReviewToSave = GroomingReview.createBy(reservation, postGroomingReviewInfo);
+        GroomingReview groomingReviewToSave = GroomingReviewMapper.createBy(reservation, postGroomingReviewInfo);
         GroomingReview SavedGroomingReview = groomingReviewPersist.save(groomingReviewToSave);
 
         //TODO 댕글미터 계산해서 영속
@@ -55,12 +56,12 @@ public class GroomingReviewService {
     }
 
     public ReviewResp modifyReview(Long reviewId, ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
-        GroomingReview savedGroomingReview = groomingReviewPersist.findBy(reviewId)
+        GroomingReview savedGroomingReview = groomingReviewPersist.findByGroomingId(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
 
         validateModifyGroomingReviewInfoDataFormat(modifyGroomingReviewInfo);
 
-        GroomingReview modifiedReview = GroomingReview.modifyBy(savedGroomingReview, modifyGroomingReviewInfo);
+        GroomingReview modifiedReview = GroomingReviewMapper.modifyBy(savedGroomingReview, modifyGroomingReviewInfo);
         GroomingReview updatedGroomingReview = groomingReviewPersist.save(modifiedReview);
 
         //TODO 댕글미터 재계산해서 영속
@@ -72,8 +73,8 @@ public class GroomingReviewService {
                 .build();
     }
 
-    public GroomingReviewDetailResp getReview(Long reviewId) {
-        GroomingReview savedGroomingReview = groomingReviewPersist.findBy(reviewId)
+    public GroomingReviewDetailResp findReview(Long reviewId) {
+        GroomingReview savedGroomingReview = groomingReviewPersist.findByGroomingId(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
 
         return GroomingReviewDetailResp.builder()
@@ -89,7 +90,7 @@ public class GroomingReviewService {
     }
 
     public ReviewResp deleteReview(Long reviewId) {
-        GroomingReview savedGroomingReview = groomingReviewPersist.findBy(reviewId)
+        GroomingReview savedGroomingReview = groomingReviewPersist.findByGroomingId(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
 
         groomingReviewPersist.delete(savedGroomingReview);
@@ -104,7 +105,7 @@ public class GroomingReviewService {
     }
 
     public List<GroomingReviewSummaryResp> findMyReviewList(Long accountId, int page, int size) {
-        User savedUser = userPersist.findBy(accountId)
+        User savedUser = userPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(page, size);
@@ -124,7 +125,7 @@ public class GroomingReviewService {
     }
 
     public List<GroomingReviewSummaryResp> findGroomerReviewList(Long groomerId, int page, int size) {
-        Groomer savedGroomer = groomerPersist.findBy(groomerId)
+        Groomer savedGroomer = groomerPersist.findByAccountId(groomerId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEWWEE_NOT_FOUNT));
 
         Pageable pageable = PageRequest.of(page, size);

--- a/daengle-user-api/src/main/java/ddog/user/application/ReservationService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/ReservationService.java
@@ -17,7 +17,7 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public ReservationSummary getReservationSummary(Long reservationId) {
-        Reservation reservation = reservationPersist.findBy(reservationId).orElseThrow(()
+        Reservation reservation = reservationPersist.findByReservationId(reservationId).orElseThrow(()
                 -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
 
         return ReservationSummary.builder()

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/CareReviewMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/CareReviewMapper.java
@@ -1,0 +1,43 @@
+package ddog.user.application.mapper;
+
+import ddog.domain.payment.Reservation;
+import ddog.domain.review.CareReview;
+import ddog.user.presentation.review.dto.ModifyCareReviewInfo;
+import ddog.user.presentation.review.dto.PostCareReviewInfo;
+
+import java.time.LocalDateTime;
+
+public class CareReviewMapper {
+
+    public static CareReview createBy(Reservation reservation, PostCareReviewInfo postCareReviewInfo) {
+        return CareReview.builder()
+                .reservationId(reservation.getReservationId())
+                .reviewerId(reservation.getCustomerId())
+                .revieweeName(reservation.getRecipientName())
+                .shopName(reservation.getShopName())
+                .starRating(postCareReviewInfo.getStarRating())
+                .content(postCareReviewInfo.getContent())
+                .createTime(LocalDateTime.now())
+                .imageUrlList(postCareReviewInfo.getImageUrlList())
+                .vetId(reservation.getRecipientId())
+                .careKeywordReviewList(postCareReviewInfo.getCareKeywordReviewList())
+                .build();
+    }
+
+    public static CareReview modifyBy(CareReview careReview, ModifyCareReviewInfo modifyCareReviewInfo) {
+        return CareReview.builder()
+                .careReviewId(careReview.getCareReviewId())
+                .reservationId(careReview.getReservationId())
+                .reviewerId(careReview.getReviewerId())
+                .vetId(careReview.getVetId())
+                .revieweeName(careReview.getRevieweeName())
+                .shopName(careReview.getShopName())
+                .starRating(modifyCareReviewInfo.getStarRating())
+                .content(modifyCareReviewInfo.getContent())
+                .createTime(careReview.getCreateTime())
+                .modifiedTime(LocalDateTime.now())
+                .imageUrlList(modifyCareReviewInfo.getImageUrlList())
+                .careKeywordReviewList(modifyCareReviewInfo.getCareKeywordReviewList())
+                .build();
+    }
+}

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingReviewMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingReviewMapper.java
@@ -1,0 +1,43 @@
+package ddog.user.application.mapper;
+
+import ddog.domain.payment.Reservation;
+import ddog.domain.review.GroomingReview;
+import ddog.user.presentation.review.dto.ModifyGroomingReviewInfo;
+import ddog.user.presentation.review.dto.PostGroomingReviewInfo;
+
+import java.time.LocalDateTime;
+
+public class GroomingReviewMapper {
+
+    public static GroomingReview createBy(Reservation reservation, PostGroomingReviewInfo postGroomingReviewInfo) {
+        return GroomingReview.builder()
+                .reservationId(reservation.getReservationId())
+                .reviewerId(reservation.getCustomerId())
+                .groomerId(reservation.getRecipientId())
+                .revieweeName(reservation.getRecipientName())
+                .shopName(reservation.getShopName())
+                .starRating(postGroomingReviewInfo.getStarRating())
+                .content(postGroomingReviewInfo.getContent())
+                .createTime(LocalDateTime.now())
+                .imageUrlList(postGroomingReviewInfo.getImageUrlList())
+                .groomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList())
+                .build();
+    }
+
+    public static GroomingReview modifyBy(GroomingReview groomingReview, ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
+        return GroomingReview.builder()
+                .groomingReviewId(groomingReview.getGroomingReviewId())
+                .reservationId(groomingReview.getReservationId())
+                .reviewerId(groomingReview.getReviewerId())
+                .groomerId(groomingReview.getGroomerId())
+                .revieweeName(groomingReview.getRevieweeName())
+                .shopName(groomingReview.getShopName())
+                .starRating(modifyGroomingReviewInfo.getStarRating())
+                .content(modifyGroomingReviewInfo.getContent())
+                .createTime(groomingReview.getCreateTime())
+                .modifiedTime(LocalDateTime.now())
+                .imageUrlList(modifyGroomingReviewInfo.getImageUrlList())
+                .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
+                .build();
+    }
+}

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/CareReviewController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/CareReviewController.java
@@ -2,8 +2,8 @@ package ddog.user.presentation.review;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
-import ddog.domain.review.dto.ModifyCareReviewInfo;
-import ddog.domain.review.dto.PostCareReviewInfo;
+import ddog.user.presentation.review.dto.ModifyCareReviewInfo;
+import ddog.user.presentation.review.dto.PostCareReviewInfo;
 import ddog.user.application.CareReviewService;
 import ddog.user.presentation.review.dto.CareReviewDetailResp;
 import ddog.user.presentation.review.dto.ReviewResp;
@@ -28,8 +28,8 @@ public class CareReviewController {
     }
 
     @GetMapping("/care/review/{reviewId}")
-    public CommonResponseEntity<CareReviewDetailResp> getReview(@PathVariable Long reviewId) {
-        return success(careReviewService.getReview(reviewId));
+    public CommonResponseEntity<CareReviewDetailResp> findReview(@PathVariable Long reviewId) {
+        return success(careReviewService.findReview(reviewId));
     }
 
     @PatchMapping("care/review/{reviewId}")

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/GroomingReviewController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/GroomingReviewController.java
@@ -2,8 +2,8 @@ package ddog.user.presentation.review;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
-import ddog.domain.review.dto.ModifyGroomingReviewInfo;
-import ddog.domain.review.dto.PostGroomingReviewInfo;
+import ddog.user.presentation.review.dto.ModifyGroomingReviewInfo;
+import ddog.user.presentation.review.dto.PostGroomingReviewInfo;
 import ddog.user.application.GroomingReviewService;
 import ddog.user.presentation.review.dto.GroomingReviewDetailResp;
 import ddog.user.presentation.review.dto.GroomingReviewSummaryResp;
@@ -28,8 +28,8 @@ public class GroomingReviewController {
     }
 
     @GetMapping("/grooming/review/{reviewId}")
-    public CommonResponseEntity<GroomingReviewDetailResp> getReview(@PathVariable Long reviewId) {
-        return success(groomingReviewService.getReview(reviewId));
+    public CommonResponseEntity<GroomingReviewDetailResp> findReview(@PathVariable Long reviewId) {
+        return success(groomingReviewService.findReview(reviewId));
     }
 
     @PatchMapping("/grooming/review/{reviewId}")

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/ModifyCareReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/ModifyCareReviewInfo.java
@@ -1,4 +1,4 @@
-package ddog.domain.review.dto;
+package ddog.user.presentation.review.dto;
 
 import ddog.domain.review.enums.CareKeywordReview;
 import lombok.Builder;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/ModifyGroomingReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/ModifyGroomingReviewInfo.java
@@ -1,4 +1,4 @@
-package ddog.domain.review.dto;
+package ddog.user.presentation.review.dto;
 
 import ddog.domain.review.enums.GroomingKeywordReview;
 import lombok.Builder;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/PostCareReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/PostCareReviewInfo.java
@@ -1,4 +1,4 @@
-package ddog.domain.review.dto;
+package ddog.user.presentation.review.dto;
 
 import ddog.domain.review.enums.CareKeywordReview;
 import lombok.Builder;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/PostGroomingReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/PostGroomingReviewInfo.java
@@ -1,4 +1,4 @@
-package ddog.domain.review.dto;
+package ddog.user.presentation.review.dto;
 
 import ddog.domain.review.enums.GroomingKeywordReview;
 import lombok.Builder;

--- a/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
@@ -23,7 +23,7 @@ public class ReviewService {
     private final VetPersist vetPersist;
 
     public List<ReviewSummaryResp> findReviewList(Long accountId, int page, int size) {
-        Vet savedVet = vetPersist.findBy(accountId)
+        Vet savedVet = vetPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(page, size);


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 효석님과 컨벤션이 달랐던 점들 중, 제가 따라가면 좋을 부분들을 리펙터링했습니다.
    - 웹서버로부터 전달받은 DTO를 통해 도메인 인스턴스를 만들어내는 정적 팩터리 메서드가 기존에는 도메인 내에 있었습니다. 
    - 웹서버의 요청값을 도메인 계층이 알아야하는 것은 확장성이 떨어집니다, (API 스펙은 언제나 바뀔 수 있기 때문에)
    - 또한, 도메인 객체의 인스턴스를 웹서버 요청값을 통해 만들어 내는 것은 어플리케이션 관심사이자 어플리케이션이 돌아가는데 필요한 연산입니다. 해서 Mapper라는 클래스를 api 모듈 내에 만들어서 활용했습니다.
    
    - 메서드 파리미터를 통해 어떠한 값으로 DB엔티티를 들고오는지 표시하고자 'findBy'만 표기해서 사용했는데, 인자의 타입이 같은 경우에 분기할 수 없습니다. 예를 들어 findy(Long userId)가 이미 있다면 findBy(Long age)를 만들 수 없습니다. findBy뒤에 insert문 where절에 활용될 멤버필드의 값을 모두 적기로 합니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
