### PR TITLE
[feat/daengle-61] Spring Security 및 로그인/온보딩 유효성 검사 과정 추가 커스텀 에러 추가

### DIFF
--- a/daengle-auth/src/main/java/ddog/auth/config/SecurityConfig.java
+++ b/daengle-auth/src/main/java/ddog/auth/config/SecurityConfig.java
@@ -55,12 +55,18 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/**", "/api/*/test/**").permitAll() // 임시로 모든 API 에 대해 통과, 각 모듈 테스트 컨트롤러 API 에 대해 통과
-                        .requestMatchers("/api/oauth/**").permitAll()  // Kakao 소셜 로그인을 위한 URL 허용
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        // 임시로 모든 API 에 대해 통과, 각 모듈 테스트 컨트롤러 API 에 대해 통과, 임시 payment 및 notification 관련 API 통과
+                        .requestMatchers("/**", "/api/*/test/**", "/api/payment/**", "/notify/**").permitAll()
+                        // Kakao 소셜 로그인을 위한 URL 허용
+                        .requestMatchers("/api/*/kakao", "/api/*/refresh-token").permitAll()
+                        // 온보딩을 위한 URL 허용
+                        .requestMatchers("/api/user/available-nickname", "/api/user/breed/list", "/api/user/join-with-pet", "/api/user/join-without-pet",
+                                "/api/groomer/join", "/api/vet/join").permitAll()
                         .requestMatchers("/api/user/**").hasRole("DAENGLE")
                         .requestMatchers("/api/groomer/**").hasRole("GROOMER")
-                        .requestMatchers("/api/vet/**").hasRole("VET"))
+                        .requestMatchers("/api/vet/**").hasRole("VET")
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/daengle-auth/src/main/java/ddog/auth/config/jwt/JwtAuthenticationFilter.java
+++ b/daengle-auth/src/main/java/ddog/auth/config/jwt/JwtAuthenticationFilter.java
@@ -24,18 +24,20 @@ import java.util.List;
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final JwtTokenProvider jwtTokenProvider;
+
     /* 필터 제외 URL 리스트 */
     private final List<String> excludeUrls = List.of(
-            "/api/oauth/kakao", "/api/oauth/refresh-token", "/test"
+            "/api/user/test", "/api/groomer/test", "/api/vet/test", "/api/payment/test",
+            "/api/user/kakao", "/api/groomer/kakao", "/api/vet/kakao", "/api/user/refresh-token", "/api/groomer/refresh-token", "/api/vet/refresh-token",
+            "/api/user/available-nickname", "/api/user/breed/list", "/api/user/join-with-pet", "/api/user/join-without-pet",
+            "/api/groomer/join", "/api/vet/join"
     );
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 
-        /* TODO 당분간 토큰 검증을 빼기 위해 임시로 넣어놓음. 나중에 꼭 빼야됨 !! */
-/*        if (true) {
-        /* 당분간 토큰 검증을 빼기 위해 임시로 넣어놓음. 나중에 꼭 빼야됨 !! */
+        /* TODO 나중에 꼭 빼기 */
         if (true) {
             chain.doFilter(request, response);
             return;
@@ -64,11 +66,20 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     }
 
     private String resolveToken(HttpServletRequest request) {
+
+        String token = request.getHeader("Authorization");
+
+        if (token == null) {
+            throw new AuthException(AuthExceptionType.MISSING_TOKEN);
+        }
+        if (token.isEmpty()) {
+            throw new AuthException(AuthExceptionType.EMPTY_TOKEN);
+        }
+
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
-
         return null;
     }
 }

--- a/daengle-auth/src/main/java/ddog/auth/config/jwt/JwtTokenProvider.java
+++ b/daengle-auth/src/main/java/ddog/auth/config/jwt/JwtTokenProvider.java
@@ -3,7 +3,6 @@ package ddog.auth.config.jwt;
 import ddog.auth.dto.TokenAccountInfoDto;
 import ddog.auth.exception.AuthException;
 import ddog.auth.exception.AuthExceptionType;
-import ddog.domain.account.port.AccountPersist;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,24 +27,22 @@ import java.util.stream.Collectors;
 public class JwtTokenProvider {
 
     private final Key key;
-    private final AccountPersist accountPersist;
     /* accessToken 만료 시간 */
-    private final int ACCESSTOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 3;    // 3일
+    private final int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 3;    // 3일
     /* refreshToken 만료 시간*/
-    private final int REFRESHTOKEN_EXPIRATION_TIME = 1000;   // 14일
+    private final int REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 14;   // 14일
 
     @Autowired
-    public JwtTokenProvider(@Value("${jwt.secret}") String secret, AccountPersist accountPersist) {
+    public JwtTokenProvider(@Value("${jwt.secret}") String secret) {
         this.key = Keys.hmacShaKeyFor(secret.getBytes());
-        this.accountPersist = accountPersist;
     }
 
     public String generateToken(Authentication authentication, HttpServletResponse response) {
-        String accessToken = createToken(authentication, ACCESSTOKEN_EXPIRATION_TIME);
-        String refreshToken = createToken(authentication, REFRESHTOKEN_EXPIRATION_TIME);
+        String accessToken = createToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+        String refreshToken = createToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME);
         response.setHeader("Set-Cookie", ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .maxAge(REFRESHTOKEN_EXPIRATION_TIME)
+                .maxAge(REFRESH_TOKEN_EXPIRATION_TIME)
                 .path("/")
                 .sameSite("None")
                 .build().toString());
@@ -55,7 +52,6 @@ public class JwtTokenProvider {
 
     private String createToken(Authentication authentication, int expirationTime) {
         Date tokenExpiration = new Date(getNowTime() + expirationTime);
-
         return Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim("auth", getAuthorities(authentication))

--- a/daengle-auth/src/main/java/ddog/auth/exception/AuthExceptionType.java
+++ b/daengle-auth/src/main/java/ddog/auth/exception/AuthExceptionType.java
@@ -11,7 +11,10 @@ public enum AuthExceptionType {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 1003, "토큰이 만료되었습니다."),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, 1004, "지원하지 않는 토큰 형식입니다."),
     UNKNOWN_TOKEN(HttpStatus.UNAUTHORIZED, 1005, "알 수 없는 토큰입니다."),
-    MISSING_AUTH_CLAIM(HttpStatus.FORBIDDEN, 1006, "토큰에 권한 정보가 없습니다."),
+    MISSING_TOKEN(HttpStatus.UNAUTHORIZED, 1006, "Authorization 헤더가 누락되었습니다."),
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, 1007, "토큰 값이 비어 있습니다."),
+    MISSING_AUTH_CLAIM(HttpStatus.FORBIDDEN, 1008, "토큰에 권한 정보가 없습니다."),
+
 
     /* 권한 관련 오류 */
     UNAVAILABLE_ROLE(HttpStatus.FORBIDDEN, 1101, "접근할 권한이 없습니다."),

--- a/daengle-domain/src/main/java/ddog/domain/account/port/AccountPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/account/port/AccountPersist.java
@@ -7,7 +7,10 @@ import java.util.Optional;
 
 public interface AccountPersist {
     boolean checkExistsAccountBy(String email, Role role);
+
     Account save(Account account);
+
     Account findById(Long accountId);
+
     Optional<Account> findAccountByEmailAndRole(String email, Role role);
 }

--- a/daengle-domain/src/main/java/ddog/domain/account/port/AccountPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/account/port/AccountPersist.java
@@ -6,7 +6,7 @@ import ddog.domain.account.Role;
 import java.util.Optional;
 
 public interface AccountPersist {
-    boolean checkExistsAccountBy(String email, Role role);
+    boolean hasAccountByEmailAndRole(String email, Role role);
 
     Account save(Account account);
 

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/auth/AuthService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/auth/AuthService.java
@@ -8,8 +8,10 @@ import ddog.auth.exception.AuthExceptionType;
 import ddog.domain.account.Account;
 import ddog.domain.account.Role;
 import ddog.domain.account.Status;
-import ddog.groomer.presentation.auth.dto.LoginResult;
 import ddog.domain.account.port.AccountPersist;
+import ddog.groomer.application.exception.account.AccountException;
+import ddog.groomer.application.exception.account.AccountExceptionType;
+import ddog.groomer.presentation.auth.dto.LoginResult;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -67,7 +69,7 @@ public class AuthService {
         authorities.add(new SimpleGrantedAuthority("ROLE_GROOMER"));
 
         Long accountId = accountPersist.findAccountByEmailAndRole(email, role)
-                .orElseThrow(() -> new RuntimeException("Account Not Found"))
+                .orElseThrow(() -> new AccountException(AccountExceptionType.ACCOUNT_NOT_FOUND))
                 .getAccountId();
 
         Authentication authentication
@@ -77,6 +79,12 @@ public class AuthService {
     }
 
     public AccessTokenInfo reGenerateAccessToken(String refreshToken, HttpServletResponse response) {
+        if (refreshToken == null) {
+            throw new AuthException(AuthExceptionType.MISSING_TOKEN);
+        }
+        if (refreshToken.isEmpty()) {
+            throw new AuthException(AuthExceptionType.EMPTY_TOKEN);
+        }
         if (!jwtTokenProvider.validateToken(refreshToken.substring(7).trim())) {
             throw new AuthException(AuthExceptionType.INVALID_TOKEN);
         }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/account/AccountExceptionType.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/account/AccountExceptionType.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum AccountExceptionType {
     INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
     ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
-    NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/AccountRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/AccountRepository.java
@@ -17,7 +17,7 @@ public class AccountRepository implements AccountPersist {
     private final AccountJpaRepository accountJpaRepository;
 
     @Override
-    public boolean checkExistsAccountBy(String email, Role role) {
+    public boolean hasAccountByEmailAndRole(String email, Role role) {
         return accountJpaRepository.existsByEmailAndRole(email, role);
     }
 

--- a/daengle-user-api/src/main/java/ddog/user/application/exception/account/AccountExceptionType.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/exception/account/AccountExceptionType.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum AccountExceptionType {
     INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
     ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
-    NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/DeployCheckController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/DeployCheckController.java
@@ -1,17 +1,28 @@
 package ddog.user.presentation;
 
+import ddog.auth.config.jwt.JwtTokenProvider;
 import jakarta.annotation.PostConstruct;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
 
 @RestController
 @RequestMapping("/api/user")
+@RequiredArgsConstructor
 public class DeployCheckController {
     private String deploymentTime;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 애플리케이션 시작 시 배포 시간을 기록
     @PostConstruct
@@ -28,5 +39,17 @@ public class DeployCheckController {
 //        String formattedDate = now.format(formatter);
         return "Hello Daengle World - MULTI MODULE !!!! USER API !" +
                 " Made at: " + deploymentTime + "   CI/CD SUCCESS";
+    }
+
+    @PostMapping("/test/accessToken")
+    public String getAccessToken(@RequestBody TokenReq tokenReq, HttpServletResponse response) {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + tokenReq.getRole().toString()));
+
+        Authentication authentication
+                = new UsernamePasswordAuthenticationToken(tokenReq.getEmail() + "," + tokenReq.getAccountId(), null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return jwtTokenProvider.generateToken(authentication, response);
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/TokenReq.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/TokenReq.java
@@ -1,0 +1,11 @@
+package ddog.user.presentation;
+
+import ddog.domain.account.Role;
+import lombok.Getter;
+
+@Getter
+public class TokenReq {
+    private String email;
+    private Role role;
+    private Long accountId;
+}

--- a/daengle-vet-api/src/main/java/ddog/vet/application/auth/AuthService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/auth/AuthService.java
@@ -9,6 +9,8 @@ import ddog.domain.account.Account;
 import ddog.domain.account.Role;
 import ddog.domain.account.Status;
 import ddog.domain.account.port.AccountPersist;
+import ddog.vet.application.exception.account.AccountException;
+import ddog.vet.application.exception.account.AccountExceptionType;
 import ddog.vet.presentation.auth.dto.LoginResult;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -68,7 +70,7 @@ public class AuthService {
         authorities.add(new SimpleGrantedAuthority("ROLE_VET"));
 
         Long accountId = accountPersist.findAccountByEmailAndRole(email, role)
-                .orElseThrow(() -> new RuntimeException("Account Not Found"))
+                .orElseThrow(() -> new AccountException(AccountExceptionType.ACCOUNT_NOT_FOUND))
                 .getAccountId();
 
         Authentication authentication
@@ -78,6 +80,12 @@ public class AuthService {
     }
 
     public AccessTokenInfo reGenerateAccessToken(String refreshToken, HttpServletResponse response) {
+        if (refreshToken == null) {
+            throw new AuthException(AuthExceptionType.MISSING_TOKEN);
+        }
+        if (refreshToken.isEmpty()) {
+            throw new AuthException(AuthExceptionType.EMPTY_TOKEN);
+        }
         if (!jwtTokenProvider.validateToken(refreshToken.substring(7).trim())) {
             throw new AuthException(AuthExceptionType.INVALID_TOKEN);
         }

--- a/daengle-vet-api/src/main/java/ddog/vet/application/exception/account/AccountExceptionType.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/exception/account/AccountExceptionType.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum AccountExceptionType {
     INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
     ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
-    NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
 
     private final HttpStatus httpStatus;
     private final Integer code;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - Spring Security 인가 URL 변경
    - Security Filter 토큰 검사 예외 URL 정리
    - JWT Token 커스트 예외 처리
    - OAuth 로그인 과정 커스텀 예외 처리
    - 이메일, 역할, 계정 ID 를 입력하면 JWT 토큰을 받는 테스트용 API 추가

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 추후 시큐리티 필터에서의 커스텀 예외를 처리해주기 위한 처리 필요함

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
