### PR TITLE
[feat/daengle-66] 결제 내역 조회 API 구현

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/payment/Order.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Order.java
@@ -23,6 +23,7 @@ public class Order {
     private Long accountId;
     private String customerName;
     private Long recipientId;
+    private String recipientImageUrl;
     private String recipientName;
     private String shopName;
     private LocalDateTime orderDate;

--- a/daengle-domain/src/main/java/ddog/domain/payment/Order.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Order.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Getter
 @Builder

--- a/daengle-domain/src/main/java/ddog/domain/payment/Payment.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Payment.java
@@ -37,10 +37,10 @@ public class Payment {
 
     public void validationSuccess(String impUid) {
         this.paymentUid = impUid;
-        this.status = PaymentStatus.COMPLETED;
+        this.status = PaymentStatus.PAYMENT_COMPLETED;
     }
 
-    public void cancel() {
-        this.status = PaymentStatus.CANCEL;
+    public void invalidate() {
+        this.status = PaymentStatus.PAYMENT_INVALIDATION;
     }
 }

--- a/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
@@ -25,6 +25,7 @@ public class Reservation {
     private LocalDateTime schedule;
     private Long deposit;
     private Long customerId;
+    private String customerName;
     private String customerPhoneNumber;
     private String visitorName;
     private String visitorPhoneNumber;

--- a/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
@@ -19,6 +19,7 @@ public class Reservation {
     private ServiceType serviceType;
     private ReservationStatus reservationStatus;
     private Long recipientId;
+    private String recipientImageUrl;
     private String recipientName;
     private String shopName;
     private LocalDateTime schedule;

--- a/daengle-domain/src/main/java/ddog/domain/payment/enums/PaymentStatus.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/enums/PaymentStatus.java
@@ -1,7 +1,18 @@
 package ddog.domain.payment.enums;
 
 public enum PaymentStatus {
-    COMPLETED,
-    READY,
-    CANCEL
+    PAYMENT_COMPLETED("결제 완료"),
+    PAYMENT_CANCELED("결제 취소"),
+    PAYMENT_INVALIDATION("유효하지 않은 결제"),
+    SERVICE_COMPLETED("서비스완료");
+
+    private final String description;
+
+    PaymentStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/daengle-domain/src/main/java/ddog/domain/payment/enums/PaymentStatus.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/enums/PaymentStatus.java
@@ -1,6 +1,7 @@
 package ddog.domain.payment.enums;
 
 public enum PaymentStatus {
+    PAYMENT_READY("결제 대기"),
     PAYMENT_COMPLETED("결제 완료"),
     PAYMENT_CANCELED("결제 취소"),
     PAYMENT_INVALIDATION("유효하지 않은 결제"),

--- a/daengle-domain/src/main/java/ddog/domain/payment/port/ReservationPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/port/ReservationPersist.java
@@ -1,6 +1,7 @@
 package ddog.domain.payment.port;
 
 import ddog.domain.payment.Reservation;
+import ddog.domain.payment.enums.ServiceType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,5 +11,5 @@ public interface ReservationPersist {
     Reservation save(Reservation reservation);
     Optional<Reservation> findByReservationId(Long reservationId);
 
-    Page<Reservation> findGroomingPaymentHistory(Long accountId, Pageable pageable);
+    Page<Reservation> findPaymentHistoryList(Long accountId, ServiceType serviceType, Pageable pageable);
 }

--- a/daengle-domain/src/main/java/ddog/domain/payment/port/ReservationPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/port/ReservationPersist.java
@@ -1,10 +1,14 @@
 package ddog.domain.payment.port;
 
 import ddog.domain.payment.Reservation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface ReservationPersist {
     Reservation save(Reservation reservation);
     Optional<Reservation> findByReservationId(Long reservationId);
+
+    Page<Reservation> findGroomingPaymentHistory(Long accountId, Pageable pageable);
 }

--- a/daengle-payment-api/build.gradle
+++ b/daengle-payment-api/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework:spring-tx'
     implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+    implementation 'org.springframework.data:spring-data-commons'
 
     // IamPort //
     implementation group: 'com.github.iamport', name: 'iamport-rest-client-java', version: '0.2.22'

--- a/daengle-payment-api/src/main/java/ddog/payment/application/PaymentService.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/PaymentService.java
@@ -19,6 +19,7 @@ import ddog.domain.user.User;
 import ddog.domain.user.port.UserPersist;
 import ddog.payment.application.dto.request.PaymentCallbackReq;
 import ddog.payment.application.dto.response.PaymentCallbackResp;
+import ddog.payment.application.dto.response.PaymentHistoryDetail;
 import ddog.payment.application.dto.response.PaymentHistoryListResp;
 import ddog.payment.application.dto.response.PaymentHistorySummaryResp;
 import ddog.payment.application.exception.*;
@@ -125,14 +126,32 @@ public class PaymentService {
         }
     }
 
-    public PaymentHistoryListResp findGroomingPaymentHistory(Long accountId, int page, int size) {
+    public PaymentHistoryListResp findPaymentHistoryList(Long accountId, ServiceType serviceType, int page, int size) {
         User savedUser = userPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new PaymentException(PaymentExceptionType.PAYMENT_USER_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<Reservation> reservations = reservationPersist.findGroomingPaymentHistory(savedUser.getAccountId(), pageable);
+        Page<Reservation> reservations = reservationPersist.findPaymentHistoryList(savedUser.getAccountId(), serviceType, pageable);
 
         return mappingToPaymentHistoryListResp(reservations);
+    }
+
+    public PaymentHistoryDetail getPaymentHistory(Long reservationId) {
+        Reservation savedReservation = reservationPersist.findByReservationId(reservationId)
+                .orElseThrow(() -> new PaymentException(PaymentExceptionType.PAYMENT_HISTORY_NOT_FOUND));
+
+        return PaymentHistoryDetail.builder()
+                .reservationId(savedReservation.getReservationId())
+                .reservationStatus(savedReservation.getReservationStatus())
+                .recipientName(savedReservation.getRecipientName())
+                .shopName(savedReservation.getShopName())
+                .schedule(savedReservation.getSchedule())
+                .deposit(savedReservation.getDeposit())
+                .customerName(savedReservation.getCustomerName())
+                .customerPhoneNumber(savedReservation.getCustomerPhoneNumber())
+                .visitorName(savedReservation.getVisitorName())
+                .visitorPhoneNumber(savedReservation.getVisitorPhoneNumber())
+                .build();
     }
 
     private PaymentHistoryListResp mappingToPaymentHistoryListResp(Page<Reservation> reservations) {

--- a/daengle-payment-api/src/main/java/ddog/payment/application/PaymentService.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/PaymentService.java
@@ -11,7 +11,6 @@ import ddog.domain.estimate.port.GroomingEstimatePersist;
 import ddog.domain.payment.Order;
 import ddog.domain.payment.Payment;
 import ddog.domain.payment.Reservation;
-import ddog.domain.payment.enums.ReservationStatus;
 import ddog.domain.payment.enums.ServiceType;
 import ddog.domain.payment.port.OrderPersist;
 import ddog.domain.payment.port.PaymentPersist;
@@ -56,7 +55,7 @@ public class PaymentService {
 
             //결제 완료 검증
             if (payment.checkIncompleteBy(paymentStatus)) {  //TODO 결제상태 변경과 영속도 도메인 엔티티에게 위임하기
-                payment.cancel();
+                payment.invalidate();
                 paymentPersist.save(payment);
 
                 throw new PaymentException(PaymentExceptionType.PAYMENT_PG_INCOMPLETE);
@@ -64,10 +63,10 @@ public class PaymentService {
 
             //결제 금액 검증
             if (payment.checkInValidationBy(paymentAmount)) {    //TODO 결제상태 변경과 영속도 도메인 엔티티에게 위임하기
-                payment.cancel();
+                payment.invalidate();
                 paymentPersist.save(payment);
-                iamportClient.cancelPaymentByImpUid(new CancelData(iamportResp.getImpUid(), true, new BigDecimal(paymentAmount)));
 
+                iamportClient.cancelPaymentByImpUid(new CancelData(iamportResp.getImpUid(), true, new BigDecimal(paymentAmount)));
                 throw new PaymentException(PaymentExceptionType.PAYMENT_PG_AMOUNT_MISMATCH);
             }
 

--- a/daengle-payment-api/src/main/java/ddog/payment/application/config/EnumUpperConverter.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/config/EnumUpperConverter.java
@@ -1,0 +1,15 @@
+package ddog.payment.application.config;
+
+import ddog.domain.payment.enums.ServiceType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class EnumUpperConverter implements Converter<String, ServiceType> {
+
+    @Override
+    public ServiceType convert(String source) {
+        return ServiceType.valueOf(source.toUpperCase());
+    }
+}

--- a/daengle-payment-api/src/main/java/ddog/payment/application/dto/request/PaymentHistoryReq.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/dto/request/PaymentHistoryReq.java
@@ -1,0 +1,4 @@
+package ddog.payment.application.dto.request;
+
+public class PaymentHistoryReq {
+}

--- a/daengle-payment-api/src/main/java/ddog/payment/application/dto/response/PaymentHistoryDetail.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/dto/response/PaymentHistoryDetail.java
@@ -1,0 +1,23 @@
+package ddog.payment.application.dto.response;
+
+import ddog.domain.payment.enums.ReservationStatus;
+import ddog.domain.payment.enums.ServiceType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PaymentHistoryDetail {
+    private Long reservationId;
+    private ReservationStatus reservationStatus;
+    private String recipientName;
+    private String shopName;
+    private LocalDateTime schedule;
+    private Long deposit;
+    private String customerName;
+    private String customerPhoneNumber;
+    private String visitorName;
+    private String visitorPhoneNumber;
+}

--- a/daengle-payment-api/src/main/java/ddog/payment/application/dto/response/PaymentHistoryListResp.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/dto/response/PaymentHistoryListResp.java
@@ -1,0 +1,12 @@
+package ddog.payment.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class PaymentHistoryListResp {
+    private List<PaymentHistorySummaryResp> paymentHistoryList;
+}

--- a/daengle-payment-api/src/main/java/ddog/payment/application/dto/response/PaymentHistorySummaryResp.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/dto/response/PaymentHistorySummaryResp.java
@@ -1,0 +1,17 @@
+package ddog.payment.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PaymentHistorySummaryResp {
+    private Long reservationId;
+    private String recipientImageUrl;
+    private String recipientName;
+    private String shopName;
+    private LocalDateTime paymentDate;
+    private String status;
+}

--- a/daengle-payment-api/src/main/java/ddog/payment/application/exception/PaymentExceptionType.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/exception/PaymentExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PaymentExceptionType {
     PAYMENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "결제자 찾을 수 없음"),
+    PAYMENT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "결제 내역 찾을 수 없음"),
     PAYMENT_PG_INTEGRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "결제 정보 조회 중 에러 발생"),
     PAYMENT_PG_INCOMPLETE(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "미완료된 결제건"),
     PAYMENT_PG_AMOUNT_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, 5003, "결제 금액 불일치");

--- a/daengle-payment-api/src/main/java/ddog/payment/application/exception/PaymentExceptionType.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/exception/PaymentExceptionType.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum PaymentExceptionType {
+    PAYMENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "결제자 찾을 수 없음"),
     PAYMENT_PG_INTEGRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "결제 정보 조회 중 에러 발생"),
     PAYMENT_PG_INCOMPLETE(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "미완료된 결제건"),
     PAYMENT_PG_AMOUNT_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, 5003, "결제 금액 불일치");

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/OrderMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/OrderMapper.java
@@ -18,6 +18,7 @@ public class OrderMapper {
                 .accountId(accountId)
                 .customerName(postOrderInfo.getCustomerName())
                 .recipientId(postOrderInfo.getRecipientId())
+                .recipientImageUrl(postOrderInfo.getRecipientImageUrl())
                 .recipientName(postOrderInfo.getRecipientName())
                 .shopName(postOrderInfo.getShopName())
                 .orderDate(LocalDateTime.now())

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/PaymentMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/PaymentMapper.java
@@ -13,7 +13,7 @@ public class PaymentMapper {
                 .paymentId(null)
                 .payerId(accountId)
                 .price(postOrderInfo.getPrice())
-                .status(PaymentStatus.READY)
+                .status(PaymentStatus.PAYMENT_READY)
                 .paymentDate(LocalDateTime.now())
                 .paymentUid(null)
                 .build();

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/ReservationMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/ReservationMapper.java
@@ -19,6 +19,7 @@ public class ReservationMapper {
                 .schedule(order.getSchedule())
                 .deposit(order.getPrice())
                 .customerId(order.getAccountId())
+                .customerName(order.getCustomerName())
                 .customerPhoneNumber(order.getCustomerPhoneNumber())
                 .visitorName(order.getVisitorName())
                 .visitorPhoneNumber(order.getVisitorPhoneNumber())

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/ReservationMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/ReservationMapper.java
@@ -13,6 +13,7 @@ public class ReservationMapper {
                 .serviceType(order.getServiceType())
                 .reservationStatus(ReservationStatus.DEPOSIT_PAID)
                 .recipientId(order.getRecipientId())  //수의사 or 병원 PK
+                .recipientImageUrl(order.getRecipientImageUrl())
                 .recipientName(order.getRecipientName())
                 .shopName(order.getShopName())
                 .schedule(order.getSchedule())

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/PaymentController.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/PaymentController.java
@@ -2,9 +2,11 @@ package ddog.payment.presentation;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
+import ddog.domain.payment.enums.ServiceType;
 import ddog.payment.application.PaymentService;
 import ddog.payment.application.dto.request.PaymentCallbackReq;
 import ddog.payment.application.dto.response.PaymentCallbackResp;
+import ddog.payment.application.dto.response.PaymentHistoryDetail;
 import ddog.payment.application.dto.response.PaymentHistoryListResp;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -24,11 +26,19 @@ public class PaymentController {
         return success(paymentService.validationPayment(paymentCallbackReq));
     }
 
-    @GetMapping("/grooming/history/list")
-    public CommonResponseEntity<PaymentHistoryListResp> findGroomingPaymentHistory(
+    @GetMapping("/{serviceType}/history/list")
+    public CommonResponseEntity<PaymentHistoryListResp> findPaymentHistoryList(
             PayloadDto payloadDto,
+            @PathVariable ServiceType serviceType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        return success(paymentService.findGroomingPaymentHistory(payloadDto.getAccountId(), page, size));
+        return success(paymentService.findPaymentHistoryList(payloadDto.getAccountId(), serviceType, page, size));
     }
+
+    @GetMapping("/history/{reservationId}")
+    public CommonResponseEntity<PaymentHistoryDetail> getPaymentHistory(
+            @PathVariable Long reservationId) {
+        return success(paymentService.getPaymentHistory(reservationId));
+    }
+
 }

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/PaymentController.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/PaymentController.java
@@ -1,14 +1,13 @@
 package ddog.payment.presentation;
 
+import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
 import ddog.payment.application.PaymentService;
 import ddog.payment.application.dto.request.PaymentCallbackReq;
 import ddog.payment.application.dto.response.PaymentCallbackResp;
+import ddog.payment.application.dto.response.PaymentHistoryListResp;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static ddog.auth.exception.common.CommonResponseEntity.success;
 
@@ -23,5 +22,13 @@ public class PaymentController {
     @PostMapping("/validate")
     public CommonResponseEntity<PaymentCallbackResp> validationPayment(@RequestBody PaymentCallbackReq paymentCallbackReq) {
         return success(paymentService.validationPayment(paymentCallbackReq));
+    }
+
+    @GetMapping("/grooming/history/list")
+    public CommonResponseEntity<PaymentHistoryListResp> findGroomingPaymentHistory(
+            PayloadDto payloadDto,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return success(paymentService.findGroomingPaymentHistory(payloadDto.getAccountId(), page, size));
     }
 }

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
@@ -12,6 +12,7 @@ public class PostOrderInfo {
     private Long estimateId;
     private ServiceType serviceType;
     private Long recipientId;
+    private String recipientImageUrl;
     private String recipientName;
     private String shopName;
     private LocalDateTime schedule;

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/ReservationRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/ReservationRepository.java
@@ -31,10 +31,9 @@ public class ReservationRepository implements ReservationPersist {
     }
 
     @Override
-    public Page<Reservation> findGroomingPaymentHistory(Long accountId, Pageable pageable) {
-        System.out.println(accountId);
+    public Page<Reservation> findPaymentHistoryList(Long accountId, ServiceType serviceType, Pageable pageable) {
         return reservationJpaRepository.findByCustomerIdAndServiceTypeAndReservationStatus(
-                        accountId, ServiceType.GROOMING, ReservationStatus.DEPOSIT_PAID, pageable)
+                        accountId, serviceType, ReservationStatus.DEPOSIT_PAID, pageable)
                 .map(ReservationJpaEntity::toModel);
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/ReservationRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/ReservationRepository.java
@@ -1,10 +1,14 @@
 package ddog.persistence.mysql.adapter;
 
 import ddog.domain.payment.Reservation;
+import ddog.domain.payment.enums.ReservationStatus;
+import ddog.domain.payment.enums.ServiceType;
 import ddog.persistence.mysql.jpa.entity.ReservationJpaEntity;
 import ddog.persistence.mysql.jpa.repository.ReservationJpaRepository;
 import ddog.domain.payment.port.ReservationPersist;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -24,5 +28,13 @@ public class ReservationRepository implements ReservationPersist {
     @Override
     public Optional<Reservation> findByReservationId(Long reservationId) {
         return reservationJpaRepository.findByReservationId(reservationId).map(ReservationJpaEntity::toModel);
+    }
+
+    @Override
+    public Page<Reservation> findGroomingPaymentHistory(Long accountId, Pageable pageable) {
+        System.out.println(accountId);
+        return reservationJpaRepository.findByCustomerIdAndServiceTypeAndReservationStatus(
+                        accountId, ServiceType.GROOMING, ReservationStatus.DEPOSIT_PAID, pageable)
+                .map(ReservationJpaEntity::toModel);
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/OrderJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/OrderJpaEntity.java
@@ -31,6 +31,7 @@ public class OrderJpaEntity {
     private Long accountId;
     private String customerName;
     private Long recipientId;
+    private String recipientImageUrl;
     private String recipientName;
     private String shopName;
     private LocalDateTime orderDate;
@@ -53,6 +54,7 @@ public class OrderJpaEntity {
                 .accountId(this.accountId)
                 .customerName(this.customerName)
                 .recipientId(this.recipientId)
+                .recipientImageUrl(this.recipientImageUrl)
                 .recipientName(this.recipientName)
                 .shopName(this.shopName)
                 .orderDate(this.orderDate)
@@ -76,6 +78,7 @@ public class OrderJpaEntity {
                 .accountId(order.getAccountId())
                 .customerName(order.getCustomerName())
                 .recipientId(order.getRecipientId())
+                .recipientImageUrl(order.getRecipientImageUrl())
                 .recipientName(order.getRecipientName())
                 .shopName(order.getShopName())
                 .orderDate(order.getOrderDate())

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ReservationJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ReservationJpaEntity.java
@@ -31,6 +31,7 @@ public class ReservationJpaEntity {
     private ReservationStatus reservationStatus;
 
     private Long recipientId;
+    private String recipientImageUrl;
     private String recipientName;
     private String shopName;
     private LocalDateTime schedule;
@@ -48,6 +49,7 @@ public class ReservationJpaEntity {
                 .serviceType(reservation.getServiceType())
                 .reservationStatus(reservation.getReservationStatus())
                 .recipientId(reservation.getRecipientId())
+                .recipientImageUrl(reservation.getRecipientImageUrl())
                 .recipientName(reservation.getRecipientName())
                 .shopName(reservation.getShopName())
                 .schedule(reservation.getSchedule())
@@ -67,6 +69,7 @@ public class ReservationJpaEntity {
                 .serviceType(serviceType)
                 .reservationStatus(reservationStatus)
                 .recipientId(recipientId)
+                .recipientImageUrl(recipientImageUrl)
                 .recipientName(recipientName)
                 .shopName(shopName)
                 .schedule(schedule)

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ReservationJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ReservationJpaEntity.java
@@ -37,6 +37,7 @@ public class ReservationJpaEntity {
     private LocalDateTime schedule;
     private Long deposit;
     private Long customerId;
+    private String customerName;
     private String customerPhoneNumber;
     private String visitorName;
     private String visitorPhoneNumber;
@@ -55,6 +56,7 @@ public class ReservationJpaEntity {
                 .schedule(reservation.getSchedule())
                 .deposit(reservation.getDeposit())
                 .customerId(reservation.getCustomerId())
+                .customerName(reservation.getCustomerName())
                 .customerPhoneNumber(reservation.getCustomerPhoneNumber())
                 .visitorName(reservation.getVisitorName())
                 .visitorPhoneNumber(reservation.getVisitorPhoneNumber())
@@ -75,6 +77,7 @@ public class ReservationJpaEntity {
                 .schedule(schedule)
                 .deposit(deposit)
                 .customerId(customerId)
+                .customerName(customerName)
                 .customerPhoneNumber(customerPhoneNumber)
                 .visitorName(visitorName)
                 .visitorPhoneNumber(visitorPhoneNumber)

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/ReservationJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/ReservationJpaRepository.java
@@ -1,6 +1,10 @@
 package ddog.persistence.mysql.jpa.repository;
 
+import ddog.domain.payment.enums.ReservationStatus;
+import ddog.domain.payment.enums.ServiceType;
 import ddog.persistence.mysql.jpa.entity.ReservationJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +12,7 @@ import java.util.Optional;
 public interface ReservationJpaRepository extends JpaRepository<ReservationJpaEntity, Long> {
 
     Optional<ReservationJpaEntity> findByReservationId(Long id);
+
+    Page<ReservationJpaEntity> findByCustomerIdAndServiceTypeAndReservationStatus(
+            Long customerId, ServiceType serviceType, ReservationStatus reservationStatus, Pageable pageable);
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 결제 내역 전체/상세 조회 API 구현

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 미용/진료 서비스를 구분하지 않고 하나의 API로 통일했습니다
    - URL PATH에 서비스 타입을 받아서 분기하는데, 이때 서비스 타입 ENUM을 그대로 경로에 집어넣어 받고자 합니다
    - 프론트 쪽에서는 PATH에 소문자를 넣고 싶어하기 때문에, 이 소문자를 ENUM의 대문자 값으로 변환할 수 있도록  컨버터 메서드를 오버라이드했습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
