### PR TITLE
[feat/daengle-64] 기존 견적서 API 조회 관련 페이징 기능 추가

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
@@ -2,6 +2,8 @@ package ddog.domain.estimate.port;
 
 import ddog.domain.estimate.CareEstimate;
 import ddog.domain.estimate.EstimateStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +20,6 @@ public interface CareEstimatePersist {
     List<CareEstimate> findCareEstimatesByVetId(Long vetId);
 
     void updateStatusWithParentId(EstimateStatus estimateStatus, Long parentId);
+
+    Page<CareEstimate> findByPetIdAndPageable(Long petId, Pageable pageable);
 }

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
@@ -27,4 +27,6 @@ public interface CareEstimatePersist {
     boolean hasGeneralEstimateByPetId(Long petId);
 
     boolean hasDesignationEstimateByPetId(Long petId);
+
+    Optional<CareEstimate> findByEstimateStatusAndProposalAndPetId(EstimateStatus estimateStatus, Proposal proposal, Long petId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
@@ -22,4 +22,6 @@ public interface CareEstimatePersist {
     void updateStatusWithParentId(EstimateStatus estimateStatus, Long parentId);
 
     Page<CareEstimate> findByPetIdAndPageable(Long petId, Pageable pageable);
+
+    boolean hasGeneralEstimateByPetId(Long petId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
@@ -2,6 +2,7 @@ package ddog.domain.estimate.port;
 
 import ddog.domain.estimate.CareEstimate;
 import ddog.domain.estimate.EstimateStatus;
+import ddog.domain.estimate.Proposal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -21,7 +22,9 @@ public interface CareEstimatePersist {
 
     void updateStatusWithParentId(EstimateStatus estimateStatus, Long parentId);
 
-    Page<CareEstimate> findByPetIdAndPageable(Long petId, Pageable pageable);
+    Page<CareEstimate> findByPetIdAndStatusAndProposal(Long petId, EstimateStatus status, Proposal proposal, Pageable pageable);
 
     boolean hasGeneralEstimateByPetId(Long petId);
+
+    boolean hasDesignationEstimateByPetId(Long petId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
@@ -22,4 +22,6 @@ public interface GroomingEstimatePersist {
     void updateStatusWithParentId(EstimateStatus estimateStatus, Long parentId);
 
     Page<GroomingEstimate> findByPetIdAndPageable(Long petId, Pageable pageable);
+
+    boolean hasGeneralEstimateByPetId(Long petId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
@@ -2,6 +2,7 @@ package ddog.domain.estimate.port;
 
 import ddog.domain.estimate.EstimateStatus;
 import ddog.domain.estimate.GroomingEstimate;
+import ddog.domain.estimate.Proposal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -17,11 +18,13 @@ public interface GroomingEstimatePersist {
 
     List<GroomingEstimate> findGroomingEstimatesByGroomerId(Long groomerId);
 
-    List<GroomingEstimate> findByPetIdAndPageable(Long petId);
+    List<GroomingEstimate> findByPetIdAndStatusAndPageable(Long petId);
 
     void updateStatusWithParentId(EstimateStatus estimateStatus, Long parentId);
 
-    Page<GroomingEstimate> findByPetIdAndPageable(Long petId, Pageable pageable);
+    Page<GroomingEstimate> findByPetIdAndStatusAndProposal(Long petId, EstimateStatus status, Proposal proposal, Pageable pageable);
 
     boolean hasGeneralEstimateByPetId(Long petId);
+
+    boolean hasDesignationEstimateByPetId(Long petId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
@@ -2,6 +2,8 @@ package ddog.domain.estimate.port;
 
 import ddog.domain.estimate.EstimateStatus;
 import ddog.domain.estimate.GroomingEstimate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +17,9 @@ public interface GroomingEstimatePersist {
 
     List<GroomingEstimate> findGroomingEstimatesByGroomerId(Long groomerId);
 
-    List<GroomingEstimate> findGroomingEstimatesByPetId(Long petId);
+    List<GroomingEstimate> findByPetIdAndPageable(Long petId);
 
     void updateStatusWithParentId(EstimateStatus estimateStatus, Long parentId);
+
+    Page<GroomingEstimate> findByPetIdAndPageable(Long petId, Pageable pageable);
 }

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
@@ -27,4 +27,6 @@ public interface GroomingEstimatePersist {
     boolean hasGeneralEstimateByPetId(Long petId);
 
     boolean hasDesignationEstimateByPetId(Long petId);
+
+    Optional<GroomingEstimate> findByEstimateStatusAndProposalAndPetId(EstimateStatus estimateStatus, Proposal proposal, Long petId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
@@ -1,5 +1,6 @@
 package ddog.domain.groomer;
 
+import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,6 +27,7 @@ public class Groomer {
     private String groomerIntroduction;
     private List<String> businessLicenses;
     private List<String> licenses;
+    private List<GroomingKeyword> keywords;
 
     public static void validateShopName(String shopName) {
         if (shopName == null || !shopName.matches("^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9\\s]{0,19}$")) {

--- a/daengle-domain/src/main/java/ddog/domain/groomer/enums/GroomingKeyword.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/enums/GroomingKeyword.java
@@ -1,11 +1,11 @@
-package ddog.domain.review.enums;
+package ddog.domain.groomer.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum GroomingKeywordReview {
+public enum GroomingKeyword {
     HYGIENIC("위생적이에요"),
     EXCELLENT_CONSULTATION("상담을 잘해 줘요"),
     STYLE_IS_GREAT("스타일이 멋져요"),

--- a/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/CareReview.java
@@ -1,13 +1,11 @@
 package ddog.domain.review;
 
-import ddog.domain.payment.Reservation;
-import ddog.domain.review.enums.CareKeywordReview;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -17,10 +15,10 @@ import java.util.List;
 public class CareReview extends Review {
     private Long careReviewId;
     private Long vetId;
-    private List<CareKeywordReview> careKeywordReviewList;
+    private List<CareKeyword> careKeywordList;
 
-    public static void validateCareKeywordReviewList(List<CareKeywordReview> careKeywordReviewList) {
-        if (careKeywordReviewList == null || careKeywordReviewList.isEmpty() || careKeywordReviewList.size() > 5) {
+    public static void validateCareKeywordReviewList(List<CareKeyword> careKeywordList) {
+        if (careKeywordList == null || careKeywordList.isEmpty() || careKeywordList.size() > 5) {
             throw new IllegalArgumentException("Care keyword review list must contain 1 to 3 items.");
         }
     }

--- a/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/GroomingReview.java
@@ -1,12 +1,11 @@
 package ddog.domain.review;
 
-import ddog.domain.review.enums.GroomingKeywordReview;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -16,10 +15,10 @@ import java.util.List;
 public class GroomingReview extends Review {
     private Long groomingReviewId;
     private Long groomerId;
-    private List<GroomingKeywordReview> groomingKeywordReviewList;
+    private List<GroomingKeyword> groomingKeywordList;
 
-    public static void validateGroomingKeywordReviewList(List<GroomingKeywordReview> groomingKeywordReviewList) {
-        if (groomingKeywordReviewList == null || groomingKeywordReviewList.isEmpty() || groomingKeywordReviewList.size() > 5) {
+    public static void validateGroomingKeywordReviewList(List<GroomingKeyword> groomingKeywordList) {
+        if (groomingKeywordList == null || groomingKeywordList.isEmpty() || groomingKeywordList.size() > 5) {
             throw new IllegalArgumentException("Grooming keyword review list must contain 1 to 3 items.");
         }
     }

--- a/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
@@ -1,6 +1,7 @@
 package ddog.domain.vet;
 
 import ddog.domain.vet.enums.AreaCode;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class Vet {
     private LocalTime endTime;
     private List<Day> closedDays;
     private List<String> licenses;
+    private List<CareKeyword> keywords;
 
     public static void validateName(String name) {
         if (name == null || name.length() < 2 || name.length() > 10 || !name.matches("^[가-힣\\s]+$")) {

--- a/daengle-domain/src/main/java/ddog/domain/vet/enums/CareKeyword.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/enums/CareKeyword.java
@@ -1,11 +1,11 @@
-package ddog.domain.review.enums;
+package ddog.domain.vet.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum CareKeywordReview {
+public enum CareKeyword {
     KIND("친절해요"),
     PROFESSIONAL("전문적이에요"),
     GOOD_AT_EXPLAINING("설명을 잘해줘요"),

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/EstimateService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/EstimateService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -42,16 +41,11 @@ public class EstimateService {
         List<GroomingEstimate> generalEstimates = groomingEstimatePersist.findGroomingEstimatesByAddress(groomer.getAddress());
         List<GroomingEstimate> designationEstimates = groomingEstimatePersist.findGroomingEstimatesByGroomerId(groomer.getAccountId());
 
-        List<EstimateInfo.Content> allContents = convertEstimatesToContents(generalEstimates);
+        List<EstimateInfo.Content> generalContents = convertEstimatesToContents(generalEstimates);
         List<EstimateInfo.Content> designationContents = convertEstimatesToContents(designationEstimates);
 
-        allContents.addAll(designationContents);
-
-        // estimateId 기준으로 오름차순 정렬
-        allContents.sort(Comparator.comparing(EstimateInfo.Content::getId));
-
         return EstimateInfo.builder()
-                .allEstimates(allContents)
+                .generalEstimates(generalContents)
                 .designationEstimates(designationContents)
                 .build();
     }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/ReviewService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/ReviewService.java
@@ -39,7 +39,7 @@ public class ReviewService {
                 .map(groomingReview -> ReviewSummaryResp.builder()
                         .groomingReviewId(groomingReview.getGroomingReviewId())
                         .groomerId(groomingReview.getGroomerId())
-                        .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
+                        .groomingKeywordList(groomingReview.getGroomingKeywordList())
                         .revieweeName(groomingReview.getRevieweeName())
                         .starRating(groomingReview.getStarRating())
                         .content(groomingReview.getContent())

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/estimate/dto/EstimateInfo.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/estimate/dto/EstimateInfo.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Builder
 public class EstimateInfo {
 
-    List<Content> allEstimates;
+    List<Content> generalEstimates;
     List<Content> designationEstimates;
 
     @Getter

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/review/dto/ReviewSummaryResp.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/review/dto/ReviewSummaryResp.java
@@ -1,6 +1,6 @@
 package ddog.groomer.presentation.review.dto;
 
-import ddog.domain.review.enums.GroomingKeywordReview;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ import java.util.List;
 public class ReviewSummaryResp {
     private Long groomingReviewId;
     private Long groomerId;
-    private List<GroomingKeywordReview> groomingKeywordReviewList;
+    private List<GroomingKeyword> groomingKeywordList;
     private String revieweeName;
     private double starRating;
     private String content;

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
@@ -6,6 +6,8 @@ import ddog.persistence.mysql.jpa.entity.CareEstimateJpaEntity;
 import ddog.persistence.mysql.jpa.repository.CareEstimateJpaRepository;
 import ddog.domain.estimate.port.CareEstimatePersist;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -50,6 +52,12 @@ public class CareEstimateRepository implements CareEstimatePersist {
     public void updateStatusWithParentId(EstimateStatus estimateStatus, Long parentId) {
         careEstimateJpaRepository.updateParentEstimateByParentId(estimateStatus, parentId);
         careEstimateJpaRepository.updateStatusByParentId(estimateStatus, parentId);
+    }
+
+    @Override
+    public Page<CareEstimate> findByPetIdAndPageable(Long petId, Pageable pageable) {
+        return careEstimateJpaRepository.findByPetId(petId, pageable)
+                .map(CareEstimateJpaEntity::toModel);
     }
 
     @Override

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
@@ -2,6 +2,7 @@ package ddog.persistence.mysql.adapter;
 
 import ddog.domain.estimate.CareEstimate;
 import ddog.domain.estimate.EstimateStatus;
+import ddog.domain.estimate.Proposal;
 import ddog.persistence.mysql.jpa.entity.CareEstimateJpaEntity;
 import ddog.persistence.mysql.jpa.repository.CareEstimateJpaRepository;
 import ddog.domain.estimate.port.CareEstimatePersist;
@@ -55,14 +56,19 @@ public class CareEstimateRepository implements CareEstimatePersist {
     }
 
     @Override
-    public Page<CareEstimate> findByPetIdAndPageable(Long petId, Pageable pageable) {
-        return careEstimateJpaRepository.findByPetId(petId, pageable)
+    public Page<CareEstimate> findByPetIdAndStatusAndProposal(Long petId, EstimateStatus status, Proposal proposal, Pageable pageable) {
+        return careEstimateJpaRepository.findByPetIdAndStatusAndProposal(petId, status, proposal, pageable)
                 .map(CareEstimateJpaEntity::toModel);
     }
 
     @Override
     public boolean hasGeneralEstimateByPetId(Long petId) {
-        return careEstimateJpaRepository.existsNewProposalByPetId(petId);
+        return careEstimateJpaRepository.existsNewAndGeneralByPetId(petId);
+    }
+
+    @Override
+    public boolean hasDesignationEstimateByPetId(Long petId) {
+        return careEstimateJpaRepository.existsNewAndDesignationByPetId(petId);
     }
 
     @Override

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
@@ -61,6 +61,11 @@ public class CareEstimateRepository implements CareEstimatePersist {
     }
 
     @Override
+    public boolean hasGeneralEstimateByPetId(Long petId) {
+        return careEstimateJpaRepository.existsNewProposalByPetId(petId);
+    }
+
+    @Override
     public Optional<CareEstimate> findByEstimateId(Long estimateId) {
         return careEstimateJpaRepository.findByEstimateId(estimateId)
                 .map(CareEstimateJpaEntity::toModel);

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
@@ -72,6 +72,12 @@ public class CareEstimateRepository implements CareEstimatePersist {
     }
 
     @Override
+    public Optional<CareEstimate> findByEstimateStatusAndProposalAndPetId(EstimateStatus estimateStatus, Proposal proposal, Long petId) {
+        return careEstimateJpaRepository.findTopByStatusAndProposalAndPetId(estimateStatus, proposal, petId)
+                .map(CareEstimateJpaEntity::toModel);
+    }
+
+    @Override
     public Optional<CareEstimate> findByEstimateId(Long estimateId) {
         return careEstimateJpaRepository.findByEstimateId(estimateId)
                 .map(CareEstimateJpaEntity::toModel);

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
@@ -6,6 +6,8 @@ import ddog.persistence.mysql.jpa.entity.GroomingEstimateJpaEntity;
 import ddog.persistence.mysql.jpa.repository.GroomingEstimateJpaRepository;
 import ddog.domain.estimate.port.GroomingEstimatePersist;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -51,7 +53,7 @@ public class GroomingEstimateRepository implements GroomingEstimatePersist {
     }
 
     @Override
-    public List<GroomingEstimate> findGroomingEstimatesByPetId(Long petId) {
+    public List<GroomingEstimate> findByPetIdAndPageable(Long petId) {
         List<GroomingEstimate> groomingEstimates = new ArrayList<>();
 
         for (GroomingEstimateJpaEntity groomingEstimateJpaEntity : groomingEstimateJpaRepository.findGroomingEstimatesByPetId(petId)) {
@@ -65,5 +67,11 @@ public class GroomingEstimateRepository implements GroomingEstimatePersist {
     public void updateStatusWithParentId(EstimateStatus estimateStatus, Long parentId) {
         groomingEstimateJpaRepository.updateParentEstimateByParentId(estimateStatus, parentId);
         groomingEstimateJpaRepository.updateStatusByParentId(estimateStatus, parentId);
+    }
+
+    @Override
+    public Page<GroomingEstimate> findByPetIdAndPageable(Long petId, Pageable pageable) {
+        return groomingEstimateJpaRepository.findByPetId(petId, pageable)
+                .map(GroomingEstimateJpaEntity::toModel);
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
@@ -74,4 +74,9 @@ public class GroomingEstimateRepository implements GroomingEstimatePersist {
         return groomingEstimateJpaRepository.findByPetId(petId, pageable)
                 .map(GroomingEstimateJpaEntity::toModel);
     }
+
+    @Override
+    public boolean hasGeneralEstimateByPetId(Long petId) {
+        return groomingEstimateJpaRepository.existsNewProposalByPetId(petId);
+    }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
@@ -2,6 +2,7 @@ package ddog.persistence.mysql.adapter;
 
 import ddog.domain.estimate.EstimateStatus;
 import ddog.domain.estimate.GroomingEstimate;
+import ddog.domain.estimate.Proposal;
 import ddog.persistence.mysql.jpa.entity.GroomingEstimateJpaEntity;
 import ddog.persistence.mysql.jpa.repository.GroomingEstimateJpaRepository;
 import ddog.domain.estimate.port.GroomingEstimatePersist;
@@ -53,7 +54,7 @@ public class GroomingEstimateRepository implements GroomingEstimatePersist {
     }
 
     @Override
-    public List<GroomingEstimate> findByPetIdAndPageable(Long petId) {
+    public List<GroomingEstimate> findByPetIdAndStatusAndPageable(Long petId) {
         List<GroomingEstimate> groomingEstimates = new ArrayList<>();
 
         for (GroomingEstimateJpaEntity groomingEstimateJpaEntity : groomingEstimateJpaRepository.findGroomingEstimatesByPetId(petId)) {
@@ -69,14 +70,18 @@ public class GroomingEstimateRepository implements GroomingEstimatePersist {
         groomingEstimateJpaRepository.updateStatusByParentId(estimateStatus, parentId);
     }
 
-    @Override
-    public Page<GroomingEstimate> findByPetIdAndPageable(Long petId, Pageable pageable) {
-        return groomingEstimateJpaRepository.findByPetId(petId, pageable)
+    public Page<GroomingEstimate> findByPetIdAndStatusAndProposal(Long petId, EstimateStatus status, Proposal proposal, Pageable pageable) {
+        return groomingEstimateJpaRepository.findByPetIdAndStatusAndProposal(petId, status, proposal, pageable)
                 .map(GroomingEstimateJpaEntity::toModel);
     }
 
     @Override
     public boolean hasGeneralEstimateByPetId(Long petId) {
-        return groomingEstimateJpaRepository.existsNewProposalByPetId(petId);
+        return groomingEstimateJpaRepository.existsNewAndGeneralByPetId(petId);
+    }
+
+    @Override
+    public boolean hasDesignationEstimateByPetId(Long petId) {
+        return groomingEstimateJpaRepository.existsNewAndDesignationByPetId(petId);
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
@@ -84,4 +84,10 @@ public class GroomingEstimateRepository implements GroomingEstimatePersist {
     public boolean hasDesignationEstimateByPetId(Long petId) {
         return groomingEstimateJpaRepository.existsNewAndDesignationByPetId(petId);
     }
+
+    @Override
+    public Optional<GroomingEstimate> findByEstimateStatusAndProposalAndPetId(EstimateStatus estimateStatus, Proposal proposal, Long petId) {
+        return groomingEstimateJpaRepository.findTopByStatusAndProposalAndPetId(estimateStatus, proposal, petId)
+                .map(GroomingEstimateJpaEntity::toModel);
+    }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/CareReviewJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/CareReviewJpaEntity.java
@@ -1,7 +1,7 @@
 package ddog.persistence.mysql.jpa.entity;
 
 import ddog.domain.review.CareReview;
-import ddog.domain.review.enums.CareKeywordReview;
+import ddog.domain.vet.enums.CareKeyword;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,7 +39,7 @@ public class CareReviewJpaEntity {
     @CollectionTable(name = "care_review_keyword_list", joinColumns = @JoinColumn(name = "care_review_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "keyword_list")
-    private List<CareKeywordReview> careKeywordReviewList;
+    private List<CareKeyword> careKeywordList;
 
     public static CareReviewJpaEntity from (CareReview careReview) {
         return CareReviewJpaEntity.builder()
@@ -54,7 +54,7 @@ public class CareReviewJpaEntity {
                 .content(careReview.getContent())
                 .createTime(careReview.getCreateTime())
                 .imageUrlList(careReview.getImageUrlList())
-                .careKeywordReviewList(careReview.getCareKeywordReviewList())
+                .careKeywordList(careReview.getCareKeywordList())
                 .build();
     }
 
@@ -70,7 +70,7 @@ public class CareReviewJpaEntity {
                 .content(content)
                 .createTime(createTime)
                 .imageUrlList(imageUrlList)
-                .careKeywordReviewList(careKeywordReviewList)
+                .careKeywordList(careKeywordList)
                 .build();
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomerJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomerJpaEntity.java
@@ -1,6 +1,7 @@
 package ddog.persistence.mysql.jpa.entity;
 
 import ddog.domain.groomer.Groomer;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,11 +35,16 @@ public class GroomerJpaEntity {
     @CollectionTable(name = "groomer_business_licenses", joinColumns = @JoinColumn(name = "groomer_id"))
     @Column(name = "business_license_url")
     private List<String> businessLicenses;
+
     @ElementCollection // 자격증 URL 리스트
     @CollectionTable(name = "groomer_licenses", joinColumns = @JoinColumn(name = "groomer_id"))
     @Column(name = "license_url")
-
     private List<String> licenses;
+
+    @ElementCollection // 해시태그 리스트
+    @CollectionTable(name = "grooming_keywords", joinColumns = @JoinColumn(name = "groomer_id"))
+    @Column(name = "grooming_keyword")
+    private List<GroomingKeyword> keywords;
 
     public static GroomerJpaEntity from(Groomer groomer) {
         return GroomerJpaEntity.builder()
@@ -55,6 +61,7 @@ public class GroomerJpaEntity {
                 .groomerIntroduction(groomer.getGroomerIntroduction())
                 .businessLicenses(groomer.getBusinessLicenses())
                 .licenses(groomer.getLicenses())
+                .keywords(groomer.getKeywords())
                 .build();
     }
 
@@ -73,6 +80,7 @@ public class GroomerJpaEntity {
                 .groomerIntroduction(groomerIntroduction)
                 .businessLicenses(businessLicenses)
                 .licenses(licenses)
+                .keywords(keywords)
                 .build();
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomingReviewJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomingReviewJpaEntity.java
@@ -1,7 +1,7 @@
 package ddog.persistence.mysql.jpa.entity;
 
 import ddog.domain.review.GroomingReview;
-import ddog.domain.review.enums.GroomingKeywordReview;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,7 +39,7 @@ public class GroomingReviewJpaEntity {
     @CollectionTable(name = "grooming_review_keyword_list", joinColumns = @JoinColumn(name = "grooming_review_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "keyword_list")
-    private List<GroomingKeywordReview> groomingKeywordReviewList;
+    private List<GroomingKeyword> groomingKeywordList;
 
     public static GroomingReviewJpaEntity from(GroomingReview groomingReview) {
         return GroomingReviewJpaEntity.builder()
@@ -54,7 +54,7 @@ public class GroomingReviewJpaEntity {
                 .content(groomingReview.getContent())
                 .createTime(groomingReview.getCreateTime())
                 .imageUrlList(groomingReview.getImageUrlList())
-                .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
+                .groomingKeywordList(groomingReview.getGroomingKeywordList())
                 .build();
     }
 
@@ -70,7 +70,7 @@ public class GroomingReviewJpaEntity {
                 .content(content)
                 .createTime(createTime)
                 .imageUrlList(imageUrlList)
-                .groomingKeywordReviewList(groomingKeywordReviewList)
+                .groomingKeywordList(groomingKeywordList)
                 .build();
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/VetJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/VetJpaEntity.java
@@ -2,6 +2,7 @@ package ddog.persistence.mysql.jpa.entity;
 
 import ddog.domain.vet.Day;
 import ddog.domain.vet.Vet;
+import ddog.domain.vet.enums.CareKeyword;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,6 +44,11 @@ public class VetJpaEntity {
     @Column(name = "license_url")
     private List<String> licenses;
 
+    @ElementCollection // 해시태그 리스트
+    @CollectionTable(name = "care_keywords", joinColumns = @JoinColumn(name = "vet_id"))
+    @Column(name = "care_keyword")
+    private List<CareKeyword> keywords;
+
     public static VetJpaEntity from(Vet vet) {
         return VetJpaEntity.builder()
                 .vetId(vet.getVetId())
@@ -59,6 +65,7 @@ public class VetJpaEntity {
                 .endTime(vet.getEndTime())
                 .closedDays(vet.getClosedDays())
                 .licenses(vet.getLicenses())
+                .keywords(vet.getKeywords())
                 .build();
     }
 
@@ -78,6 +85,7 @@ public class VetJpaEntity {
                 .endTime(endTime)
                 .closedDays(closedDays)
                 .licenses(licenses)
+                .keywords(keywords)
                 .build();
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
@@ -2,6 +2,8 @@ package ddog.persistence.mysql.jpa.repository;
 
 import ddog.domain.estimate.EstimateStatus;
 import ddog.persistence.mysql.jpa.entity.CareEstimateJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -39,4 +41,6 @@ public interface CareEstimateJpaRepository extends JpaRepository<CareEstimateJpa
     @Transactional
     @Query("UPDATE CareEstimates c SET c.status = :status WHERE c.parentId = :parentId")
     void updateStatusByParentId(@Param("status") EstimateStatus status, @Param("parentId") Long parentId);
+
+    Page<CareEstimateJpaEntity> findByPetId(Long petId, Pageable pageable);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
@@ -43,4 +43,8 @@ public interface CareEstimateJpaRepository extends JpaRepository<CareEstimateJpa
     void updateStatusByParentId(@Param("status") EstimateStatus status, @Param("parentId") Long parentId);
 
     Page<CareEstimateJpaEntity> findByPetId(Long petId, Pageable pageable);
+
+    @Query("SELECT CASE WHEN COUNT(g) > 0 THEN TRUE ELSE FALSE END " +
+            "FROM CareEstimates g WHERE g.proposal = 'NEW' AND g.petId = :petId")
+    boolean existsNewProposalByPetId(@Param("petId") Long petId);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
@@ -1,6 +1,7 @@
 package ddog.persistence.mysql.jpa.repository;
 
 import ddog.domain.estimate.EstimateStatus;
+import ddog.domain.estimate.Proposal;
 import ddog.persistence.mysql.jpa.entity.CareEstimateJpaEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -42,9 +43,13 @@ public interface CareEstimateJpaRepository extends JpaRepository<CareEstimateJpa
     @Query("UPDATE CareEstimates c SET c.status = :status WHERE c.parentId = :parentId")
     void updateStatusByParentId(@Param("status") EstimateStatus status, @Param("parentId") Long parentId);
 
-    Page<CareEstimateJpaEntity> findByPetId(Long petId, Pageable pageable);
+    Page<CareEstimateJpaEntity> findByPetIdAndStatusAndProposal(Long petId, EstimateStatus status, Proposal proposal, Pageable pageable);
 
     @Query("SELECT CASE WHEN COUNT(g) > 0 THEN TRUE ELSE FALSE END " +
-            "FROM CareEstimates g WHERE g.proposal = 'NEW' AND g.petId = :petId")
-    boolean existsNewProposalByPetId(@Param("petId") Long petId);
+            "FROM CareEstimates g WHERE g.status = 'NEW' AND g.proposal = 'GENERAL' AND g.petId = :petId")
+    boolean existsNewAndGeneralByPetId(@Param("petId") Long petId);
+
+    @Query("SELECT CASE WHEN COUNT(g) > 0 THEN TRUE ELSE FALSE END " +
+            "FROM CareEstimates g WHERE g.status = 'NEW' AND g.proposal = 'DESIGNATION' AND g.petId = :petId")
+    boolean existsNewAndDesignationByPetId(@Param("petId") Long petId);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
@@ -52,4 +52,6 @@ public interface CareEstimateJpaRepository extends JpaRepository<CareEstimateJpa
     @Query("SELECT CASE WHEN COUNT(g) > 0 THEN TRUE ELSE FALSE END " +
             "FROM CareEstimates g WHERE g.status = 'NEW' AND g.proposal = 'DESIGNATION' AND g.petId = :petId")
     boolean existsNewAndDesignationByPetId(@Param("petId") Long petId);
+
+    Optional<CareEstimateJpaEntity> findTopByStatusAndProposalAndPetId(EstimateStatus status, Proposal proposal, Long petId);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
@@ -1,6 +1,7 @@
 package ddog.persistence.mysql.jpa.repository;
 
 import ddog.domain.estimate.EstimateStatus;
+import ddog.domain.estimate.Proposal;
 import ddog.persistence.mysql.jpa.entity.GroomingEstimateJpaEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,9 +42,13 @@ public interface GroomingEstimateJpaRepository extends JpaRepository<GroomingEst
     @Query("UPDATE GroomingEstimates g SET g.status = :status WHERE g.parentId = :parentId")
     void updateStatusByParentId(@Param("status") EstimateStatus status, @Param("parentId") Long parentId);
 
-    Page<GroomingEstimateJpaEntity> findByPetId(Long petId, Pageable pageable);
+    Page<GroomingEstimateJpaEntity> findByPetIdAndStatusAndProposal(Long petId, EstimateStatus status, Proposal proposal, Pageable pageable);
 
     @Query("SELECT CASE WHEN COUNT(g) > 0 THEN TRUE ELSE FALSE END " +
-            "FROM GroomingEstimates g WHERE g.proposal = 'NEW' AND g.petId = :petId")
-    boolean existsNewProposalByPetId(@Param("petId") Long petId);
+            "FROM GroomingEstimates g WHERE g.status = 'NEW' AND g.proposal = 'GENERAL' AND g.petId = :petId")
+    boolean existsNewAndGeneralByPetId(@Param("petId") Long petId);
+
+    @Query("SELECT CASE WHEN COUNT(g) > 0 THEN TRUE ELSE FALSE END " +
+            "FROM GroomingEstimates g WHERE g.status = 'NEW' AND g.proposal = 'DESIGNATION' AND g.petId = :petId")
+    boolean existsNewAndDesignationByPetId(@Param("petId") Long petId);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
@@ -42,4 +42,8 @@ public interface GroomingEstimateJpaRepository extends JpaRepository<GroomingEst
     void updateStatusByParentId(@Param("status") EstimateStatus status, @Param("parentId") Long parentId);
 
     Page<GroomingEstimateJpaEntity> findByPetId(Long petId, Pageable pageable);
+
+    @Query("SELECT CASE WHEN COUNT(g) > 0 THEN TRUE ELSE FALSE END " +
+            "FROM GroomingEstimates g WHERE g.proposal = 'NEW' AND g.petId = :petId")
+    boolean existsNewProposalByPetId(@Param("petId") Long petId);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
@@ -2,6 +2,8 @@ package ddog.persistence.mysql.jpa.repository;
 
 import ddog.domain.estimate.EstimateStatus;
 import ddog.persistence.mysql.jpa.entity.GroomingEstimateJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -38,4 +40,6 @@ public interface GroomingEstimateJpaRepository extends JpaRepository<GroomingEst
     @Transactional
     @Query("UPDATE GroomingEstimates g SET g.status = :status WHERE g.parentId = :parentId")
     void updateStatusByParentId(@Param("status") EstimateStatus status, @Param("parentId") Long parentId);
+
+    Page<GroomingEstimateJpaEntity> findByPetId(Long petId, Pageable pageable);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
@@ -48,6 +48,8 @@ public interface GroomingEstimateJpaRepository extends JpaRepository<GroomingEst
             "FROM GroomingEstimates g WHERE g.status = 'NEW' AND g.proposal = 'GENERAL' AND g.petId = :petId")
     boolean existsNewAndGeneralByPetId(@Param("petId") Long petId);
 
+    Optional<GroomingEstimateJpaEntity> findTopByStatusAndProposalAndPetId(EstimateStatus status, Proposal proposal, Long petId);
+
     @Query("SELECT CASE WHEN COUNT(g) > 0 THEN TRUE ELSE FALSE END " +
             "FROM GroomingEstimates g WHERE g.status = 'NEW' AND g.proposal = 'DESIGNATION' AND g.petId = :petId")
     boolean existsNewAndDesignationByPetId(@Param("petId") Long petId);

--- a/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
@@ -105,7 +105,7 @@ public class CareReviewService {
         return CareReviewDetailResp.builder()
                 .careReviewId(savedCareReview.getCareReviewId())
                 .vetId(savedCareReview.getVetId())
-                .careKeywordReviewList(savedCareReview.getCareKeywordReviewList())
+                .careKeywordList(savedCareReview.getCareKeywordList())
                 .revieweeName(savedCareReview.getRevieweeName())
                 .shopName(savedCareReview.getShopName())
                 .starRating(savedCareReview.getStarRating())
@@ -137,14 +137,14 @@ public class CareReviewService {
 
     private void validatePostCareReviewInfoDataFormat(PostCareReviewInfo postCareReviewInfo) {
         CareReview.validateStarRating(postCareReviewInfo.getStarRating());
-        CareReview.validateCareKeywordReviewList(postCareReviewInfo.getCareKeywordReviewList());
+        CareReview.validateCareKeywordReviewList(postCareReviewInfo.getCareKeywordList());
         CareReview.validateContent(postCareReviewInfo.getContent());
         CareReview.validateImageUrlList(postCareReviewInfo.getImageUrlList());
     }
 
     private void validateModifyCareReviewInfoDataFormat(ModifyCareReviewInfo modifyCareReviewInfo) {
         CareReview.validateStarRating(modifyCareReviewInfo.getStarRating());
-        CareReview.validateCareKeywordReviewList(modifyCareReviewInfo.getCareKeywordReviewList());
+        CareReview.validateCareKeywordReviewList(modifyCareReviewInfo.getCareKeywordList());
         CareReview.validateContent(modifyCareReviewInfo.getContent());
         CareReview.validateImageUrlList(modifyCareReviewInfo.getImageUrlList());
     }
@@ -160,7 +160,7 @@ public class CareReviewService {
                     .reviewerName(reviewer.getUsername())
                     .reviewerImageUrl(reviewer.getUserImage())
                     .vetId(careReview.getVetId())
-                    .careKeywordReviewList(careReview.getCareKeywordReviewList())
+                    .careKeywordList(careReview.getCareKeywordList())
                     .revieweeName(careReview.getRevieweeName())
                     .starRating(careReview.getStarRating())
                     .content(careReview.getContent())

--- a/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
@@ -129,13 +129,13 @@ public class EstimateService {
         List<Pet> pets = user.getPets();
         List<EstimateInfo.Pet.Content> contents = new ArrayList<>();
         for (Pet pet : pets) {
-            if (groomingEstimatePersist.hasGeneralEstimateByPetId(pet.getPetId())) {
-                contents.add(EstimateInfo.Pet.Content.builder()
-                        .id(pet.getPetId())
-                        .imageURL(pet.getPetImage())
-                        .name(pet.getPetName())
-                        .build());
-            }
+            groomingEstimatePersist.findByEstimateStatusAndProposalAndPetId(EstimateStatus.NEW, Proposal.GENERAL, pet.getPetId())
+                    .ifPresent(estimate -> contents.add(EstimateInfo.Pet.Content.builder()
+                            .estimateId(estimate.getEstimateId())
+                            .petId(pet.getPetId())
+                            .imageURL(pet.getPetImage())
+                            .name(pet.getPetName())
+                            .build()));
         }
         return EstimateInfo.Pet.builder()
                 .pets(contents)
@@ -149,13 +149,13 @@ public class EstimateService {
         List<Pet> pets = user.getPets();
         List<EstimateInfo.Pet.Content> contents = new ArrayList<>();
         for (Pet pet : pets) {
-            if (careEstimatePersist.hasGeneralEstimateByPetId(pet.getPetId())) {
-                contents.add(EstimateInfo.Pet.Content.builder()
-                        .id(pet.getPetId())
-                        .imageURL(pet.getPetImage())
-                        .name(pet.getPetName())
-                        .build());
-            }
+            careEstimatePersist.findByEstimateStatusAndProposalAndPetId(EstimateStatus.NEW, Proposal.GENERAL, pet.getPetId())
+                    .ifPresent(estimate -> contents.add(EstimateInfo.Pet.Content.builder()
+                            .estimateId(estimate.getEstimateId())
+                            .petId(pet.getPetId())
+                            .imageURL(pet.getPetImage())
+                            .name(pet.getPetName())
+                            .build()));
         }
         return EstimateInfo.Pet.builder()
                 .pets(contents)
@@ -188,13 +188,13 @@ public class EstimateService {
         List<Pet> pets = user.getPets();
         List<EstimateInfo.Pet.Content> contents = new ArrayList<>();
         for (Pet pet : pets) {
-            if (groomingEstimatePersist.hasDesignationEstimateByPetId(pet.getPetId())) {
-                contents.add(EstimateInfo.Pet.Content.builder()
-                        .id(pet.getPetId())
-                        .imageURL(pet.getPetImage())
-                        .name(pet.getPetName())
-                        .build());
-            }
+            groomingEstimatePersist.findByEstimateStatusAndProposalAndPetId(EstimateStatus.NEW, Proposal.DESIGNATION, pet.getPetId())
+                    .ifPresent(estimate -> contents.add(EstimateInfo.Pet.Content.builder()
+                            .estimateId(estimate.getEstimateId())
+                            .petId(pet.getPetId())
+                            .imageURL(pet.getPetImage())
+                            .name(pet.getPetName())
+                            .build()));
         }
         return EstimateInfo.Pet.builder()
                 .pets(contents)
@@ -209,13 +209,13 @@ public class EstimateService {
         List<Pet> pets = user.getPets();
         List<EstimateInfo.Pet.Content> contents = new ArrayList<>();
         for (Pet pet : pets) {
-            if (careEstimatePersist.hasDesignationEstimateByPetId(pet.getPetId())) {
-                contents.add(EstimateInfo.Pet.Content.builder()
-                        .id(pet.getPetId())
-                        .imageURL(pet.getPetImage())
-                        .name(pet.getPetName())
-                        .build());
-            }
+            careEstimatePersist.findByEstimateStatusAndProposalAndPetId(EstimateStatus.NEW, Proposal.DESIGNATION, pet.getPetId())
+                    .ifPresent(estimate -> contents.add(EstimateInfo.Pet.Content.builder()
+                            .estimateId(estimate.getEstimateId())
+                            .petId(pet.getPetId())
+                            .imageURL(pet.getPetImage())
+                            .name(pet.getPetName())
+                            .build()));
         }
         return EstimateInfo.Pet.builder()
                 .pets(contents)

--- a/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
@@ -121,6 +121,47 @@ public class EstimateService {
     }
 
     @Transactional(readOnly = true)
+    public EstimateInfo.Pet findGeneralGroomingPets(Long accountId) {
+        User user = userPersist.findByAccountId(accountId)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        List<Pet> pets = user.getPets();
+        List<EstimateInfo.Pet.Content> contents = new ArrayList<>();
+        for (Pet pet : pets) {
+            if (groomingEstimatePersist.hasGeneralEstimateByPetId(pet.getPetId())) {
+                contents.add(EstimateInfo.Pet.Content.builder()
+                        .id(pet.getPetId())
+                        .imageURL(pet.getPetImage())
+                        .name(pet.getPetName())
+                        .build());
+            }
+        }
+        return EstimateInfo.Pet.builder()
+                .pets(contents)
+                .build();
+    }
+
+    public EstimateInfo.Pet findGeneralCarePets(Long accountId) {
+        User user = userPersist.findByAccountId(accountId)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        List<Pet> pets = user.getPets();
+        List<EstimateInfo.Pet.Content> contents = new ArrayList<>();
+        for (Pet pet : pets) {
+            if (careEstimatePersist.hasGeneralEstimateByPetId(pet.getPetId())) {
+                contents.add(EstimateInfo.Pet.Content.builder()
+                        .id(pet.getPetId())
+                        .imageURL(pet.getPetImage())
+                        .name(pet.getPetName())
+                        .build());
+            }
+        }
+        return EstimateInfo.Pet.builder()
+                .pets(contents)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
     public EstimateInfo.Grooming findGeneralGroomingEstimates(Long petId, int page, int size) {
 
         Pageable pageable = PageRequest.of(page, size);

--- a/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
@@ -230,6 +230,14 @@ public class EstimateService {
         return groomingEstimatesToContents(estimates);
     }
 
+    @Transactional(readOnly = true)
+    public EstimateInfo.Care findDesignationCareEstimates(Long petId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<CareEstimate> estimates = careEstimatePersist.findByPetIdAndStatusAndProposal(petId, EstimateStatus.PENDING, Proposal.DESIGNATION, pageable);
+
+        return careEstimatesToContents(estimates);
+    }
+
     private EstimateInfo.Grooming groomingEstimatesToContents(Page<GroomingEstimate> estimates) {
         List<EstimateInfo.Grooming.Content> contents = new ArrayList<>();
         for (GroomingEstimate estimate : estimates) {
@@ -242,14 +250,6 @@ public class EstimateService {
         return EstimateInfo.Grooming.builder()
                 .estimates(contents)
                 .build();
-    }
-
-    @Transactional(readOnly = true)
-    public EstimateInfo.Care findDesignationCareEstimates(Long petId, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<CareEstimate> estimates = careEstimatePersist.findByPetIdAndStatusAndProposal(petId, EstimateStatus.PENDING, Proposal.DESIGNATION, pageable);
-
-        return careEstimatesToContents(estimates);
     }
 
     private EstimateInfo.Care careEstimatesToContents(Page<CareEstimate> estimates) {

--- a/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
@@ -108,7 +108,7 @@ public class GroomingReviewService {
         return GroomingReviewDetailResp.builder()
                 .groomingReviewId(savedGroomingReview.getGroomingReviewId())
                 .groomerId(savedGroomingReview.getGroomerId())
-                .groomingKeywordReviewList(savedGroomingReview.getGroomingKeywordReviewList())
+                .groomingKeywordList(savedGroomingReview.getGroomingKeywordList())
                 .revieweeName(savedGroomingReview.getRevieweeName())
                 .shopName(savedGroomingReview.getShopName())
                 .starRating(savedGroomingReview.getStarRating())
@@ -141,14 +141,14 @@ public class GroomingReviewService {
 
     private void validatePostGroomingReviewInfoDataFormat(PostGroomingReviewInfo postGroomingReviewInfo) {
         GroomingReview.validateStarRating(postGroomingReviewInfo.getStarRating());
-        GroomingReview.validateGroomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList());
+        GroomingReview.validateGroomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordList());
         GroomingReview.validateContent(postGroomingReviewInfo.getContent());
         GroomingReview.validateImageUrlList(postGroomingReviewInfo.getImageUrlList());
     }
 
     private void validateModifyGroomingReviewInfoDataFormat(ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
         GroomingReview.validateStarRating(modifyGroomingReviewInfo.getStarRating());
-        GroomingReview.validateGroomingKeywordReviewList(modifyGroomingReviewInfo.getGroomingKeywordReviewList());
+        GroomingReview.validateGroomingKeywordReviewList(modifyGroomingReviewInfo.getGroomingKeywordList());
         GroomingReview.validateContent(modifyGroomingReviewInfo.getContent());
         GroomingReview.validateImageUrlList(modifyGroomingReviewInfo.getImageUrlList());
     }
@@ -164,7 +164,7 @@ public class GroomingReviewService {
                     .reviewerName(reviewer.getUsername())
                     .reviewerImageUrl(reviewer.getUserImage())
                     .groomerId(groomingReview.getGroomerId())
-                    .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
+                    .groomingKeywordList(groomingReview.getGroomingKeywordList())
                     .revieweeName(groomingReview.getRevieweeName())
                     .starRating(groomingReview.getStarRating())
                     .content(groomingReview.getContent())

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/CareEstimateMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/CareEstimateMapper.java
@@ -77,13 +77,13 @@ public class CareEstimateMapper {
                 .build();
     }
 
-    public static EstimateInfo.PetInfo.Care mapToCare(CareEstimate estimate, Vet vet) {
-        return EstimateInfo.PetInfo.Care.builder()
-                .careEstimateId(estimate.getEstimateId())
+    public static EstimateInfo.Care.Content mapToEstimateInfo(CareEstimate estimate, Vet vet) {
+        return EstimateInfo.Care.Content.builder()
+                .id(estimate.getEstimateId())
                 .name(vet.getVetName())
                 .daengleMeter(vet.getDaengleMeter())
-                .proposal(estimate.getProposal())
-                .image(vet.getVetImage())
+                .imageURL(vet.getVetImage())
+                .keywords(vet.getKeywords())
                 .reservedDate(estimate.getReservedDate())
                 .build();
     }

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/CareReviewMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/CareReviewMapper.java
@@ -20,7 +20,7 @@ public class CareReviewMapper {
                 .createTime(LocalDateTime.now())
                 .imageUrlList(postCareReviewInfo.getImageUrlList())
                 .vetId(reservation.getRecipientId())
-                .careKeywordReviewList(postCareReviewInfo.getCareKeywordReviewList())
+                .careKeywordList(postCareReviewInfo.getCareKeywordList())
                 .build();
     }
 
@@ -37,7 +37,7 @@ public class CareReviewMapper {
                 .createTime(careReview.getCreateTime())
                 .modifiedTime(LocalDateTime.now())
                 .imageUrlList(modifyCareReviewInfo.getImageUrlList())
-                .careKeywordReviewList(modifyCareReviewInfo.getCareKeywordReviewList())
+                .careKeywordList(modifyCareReviewInfo.getCareKeywordList())
                 .build();
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingEstimateMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingEstimateMapper.java
@@ -7,6 +7,7 @@ import ddog.domain.groomer.Groomer;
 import ddog.domain.pet.Pet;
 import ddog.domain.user.User;
 import ddog.user.presentation.estimate.dto.*;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -78,14 +79,14 @@ public class GroomingEstimateMapper {
                 .build();
     }
 
-    public static EstimateInfo.PetInfo.Grooming mapToGrooming(GroomingEstimate estimate, Groomer groomer) {
-        return EstimateInfo.PetInfo.Grooming.builder()
-                .groomingEstimateId(estimate.getEstimateId())
+    public static EstimateInfo.Grooming.Content mapToEstimateInfo(GroomingEstimate estimate, Groomer groomer) {
+        return EstimateInfo.Grooming.Content.builder()
+                .id(estimate.getEstimateId())
                 .name(groomer.getGroomerName())
                 .daengleMeter(groomer.getDaengleMeter())
-                .proposal(estimate.getProposal())
-                .image(groomer.getGroomerImage())
+                .imageURL(groomer.getGroomerImage())
                 .shopName(groomer.getShopName())
+                .keywords(groomer.getKeywords())
                 .reservedDate(estimate.getReservedDate())
                 .build();
     }

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingReviewMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingReviewMapper.java
@@ -20,7 +20,7 @@ public class GroomingReviewMapper {
                 .content(postGroomingReviewInfo.getContent())
                 .createTime(LocalDateTime.now())
                 .imageUrlList(postGroomingReviewInfo.getImageUrlList())
-                .groomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList())
+                .groomingKeywordList(postGroomingReviewInfo.getGroomingKeywordList())
                 .build();
     }
 
@@ -37,7 +37,7 @@ public class GroomingReviewMapper {
                 .createTime(groomingReview.getCreateTime())
                 .modifiedTime(LocalDateTime.now())
                 .imageUrlList(modifyGroomingReviewInfo.getImageUrlList())
-                .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
+                .groomingKeywordList(groomingReview.getGroomingKeywordList())
                 .build();
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/PetMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/PetMapper.java
@@ -12,6 +12,7 @@ public class PetMapper {
                 .accountId(accountId)
                 .petName(request.getPetName())
                 .petGender(request.getPetGender())
+                .petImage("")
                 .petWeight(request.getPetWeight())
                 .petBirth(request.getPetBirth())
                 .isNeutered(request.getIsNeutered())

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
@@ -42,10 +42,24 @@ public class EstimateController {
         return success(estimateService.createNewCareEstimate(request, payloadDto.getAccountId()));
     }
 
-    /* 미용/진료 (대기) 견적서 상세 조회 */
-    @GetMapping("/list")
-    public CommonResponseEntity<EstimateInfo> findEstimates(PayloadDto payloadDto) {
-        return success(estimateService.findEstimates(payloadDto.getAccountId()));
+    /* (일반) 대기 미용 견적서 리스트 조회 */
+    @GetMapping("/general/grooming/{petId}")
+    public CommonResponseEntity<EstimateInfo.Grooming> findGeneralGroomingEstimates(
+            @PathVariable Long petId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return success(estimateService.findGeneralGroomingEstimates(petId, page, size));
+    }
+
+    /* (일반) 대기 진료 견적서 리스트 조회 */
+    @GetMapping("/general/care/{petId}")
+    public CommonResponseEntity<EstimateInfo.Care> findGeneralCareEstimates(
+            @PathVariable Long petId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return success(estimateService.findGeneralCareEstimates(petId, page, size));
     }
 
     /* 사용자가 작성한 미용 견적서 조회 */

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
@@ -75,12 +75,36 @@ public class EstimateController {
     }
 
     /* (지정) 대기 미용 견적서 페이지 반려동물 정보 반환 */
+    @GetMapping("/designation/grooming")
+    public CommonResponseEntity<EstimateInfo.Pet> findDesignationGroomingPets(PayloadDto payloadDto) {
+        return success(estimateService.findDesignationGroomingPets(payloadDto.getAccountId()));
+    }
 
     /* (지정) 대기 진료 견적서 페이지 반려동물 정보 반환 */
+    @GetMapping("/designation/care")
+    public CommonResponseEntity<EstimateInfo.Pet> findDesignationCarePets(PayloadDto payloadDto) {
+        return success(estimateService.findDesignationCarePets(payloadDto.getAccountId()));
+    }
 
     /* (지정) 대기 미용 견적서 리스트 조회 */
+    @GetMapping("/designation/grooming/{petId}")
+    public CommonResponseEntity<EstimateInfo.Grooming> findDesignationGroomingEstimates(
+            @PathVariable Long petId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return success(estimateService.findDesignationGroomingEstimates(petId, page, size));
+    }
 
     /* (지정) 대기 진료 견적서 리스트 조회 */
+    @GetMapping("/designation/care/{petId}")
+    public CommonResponseEntity<EstimateInfo.Care> findDesignationCareEstimates(
+            @PathVariable Long petId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return success(estimateService.findDesignationCareEstimates(petId, page, size));
+    }
 
     /* 사용자가 작성한 미용 견적서 조회 */
     @GetMapping("/request/grooming/{estimateId}")

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
@@ -43,13 +43,13 @@ public class EstimateController {
     }
 
     /* (일반) 대기 미용 견적서 페이지 반려동물 정보 반환 */
-    @GetMapping("/general/grooming")
+    @GetMapping("/general/grooming/pets")
     public CommonResponseEntity<EstimateInfo.Pet> findGeneralGroomingPets(PayloadDto payloadDto) {
         return success(estimateService.findGeneralGroomingPets(payloadDto.getAccountId()));
     }
 
     /* (일반) 대기 진료 견적서 페이지 반려동물 정보 반환 */
-    @GetMapping("/general/care")
+    @GetMapping("/general/care/pets")
     public CommonResponseEntity<EstimateInfo.Pet> findGeneralCarePets(PayloadDto payloadDto) {
         return success(estimateService.findGeneralCarePets(payloadDto.getAccountId()));
     }
@@ -75,13 +75,13 @@ public class EstimateController {
     }
 
     /* (지정) 대기 미용 견적서 페이지 반려동물 정보 반환 */
-    @GetMapping("/designation/grooming")
+    @GetMapping("/designation/grooming/pets")
     public CommonResponseEntity<EstimateInfo.Pet> findDesignationGroomingPets(PayloadDto payloadDto) {
         return success(estimateService.findDesignationGroomingPets(payloadDto.getAccountId()));
     }
 
     /* (지정) 대기 진료 견적서 페이지 반려동물 정보 반환 */
-    @GetMapping("/designation/care")
+    @GetMapping("/designation/care/pets")
     public CommonResponseEntity<EstimateInfo.Pet> findDesignationCarePets(PayloadDto payloadDto) {
         return success(estimateService.findDesignationCarePets(payloadDto.getAccountId()));
     }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
@@ -42,6 +42,18 @@ public class EstimateController {
         return success(estimateService.createNewCareEstimate(request, payloadDto.getAccountId()));
     }
 
+    /* (일반) 대기 미용 견적서 페이지 반려동물 정보 반환 */
+    @GetMapping("/general/grooming")
+    public CommonResponseEntity<EstimateInfo.Pet> findGeneralGroomingPets(PayloadDto payloadDto) {
+        return success(estimateService.findGeneralGroomingPets(payloadDto.getAccountId()));
+    }
+
+    /* (일반) 대기 진료 견적서 페이지 반려동물 정보 반환 */
+    @GetMapping("/general/care")
+    public CommonResponseEntity<EstimateInfo.Pet> findGeneralCarePets(PayloadDto payloadDto) {
+        return success(estimateService.findGeneralCarePets(payloadDto.getAccountId()));
+    }
+
     /* (일반) 대기 미용 견적서 리스트 조회 */
     @GetMapping("/general/grooming/{petId}")
     public CommonResponseEntity<EstimateInfo.Grooming> findGeneralGroomingEstimates(
@@ -61,6 +73,14 @@ public class EstimateController {
     ) {
         return success(estimateService.findGeneralCareEstimates(petId, page, size));
     }
+
+    /* (지정) 대기 미용 견적서 페이지 반려동물 정보 반환 */
+
+    /* (지정) 대기 진료 견적서 페이지 반려동물 정보 반환 */
+
+    /* (지정) 대기 미용 견적서 리스트 조회 */
+
+    /* (지정) 대기 진료 견적서 리스트 조회 */
 
     /* 사용자가 작성한 미용 견적서 조회 */
     @GetMapping("/request/grooming/{estimateId}")

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/dto/EstimateInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/dto/EstimateInfo.java
@@ -1,7 +1,6 @@
 package ddog.user.presentation.estimate.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import ddog.domain.estimate.Proposal;
 import ddog.domain.groomer.enums.GroomingKeyword;
 import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
@@ -13,6 +12,21 @@ import java.util.List;
 @Getter
 @Builder
 public class EstimateInfo {
+
+    @Getter
+    @Builder
+    public static class Pet {
+
+        private List<Content> pets;
+
+        @Getter
+        @Builder
+        public static class Content {
+            private Long id;
+            private String imageURL;
+            private String name;
+        }
+    }
 
     @Getter
     @Builder

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/dto/EstimateInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/dto/EstimateInfo.java
@@ -2,6 +2,8 @@ package ddog.user.presentation.estimate.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import ddog.domain.estimate.Proposal;
+import ddog.domain.groomer.enums.GroomingKeyword;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,41 +14,41 @@ import java.util.List;
 @Builder
 public class EstimateInfo {
 
-    List<PetInfo> petInfos;
-
     @Getter
     @Builder
-    public static class PetInfo {
-        private Long petId;
-        private String name;
-        private String image;
-        private Long groomingParentId;
-        private Long careParentId;
-        List<Grooming> groomingEstimates;
-        List<Care> careEstimates;
+    public static class Grooming {
+
+        private List<Content> estimates;
 
         @Getter
         @Builder
-        public static class Grooming {
-            private Long groomingEstimateId;
+        public static class Content {
+            private Long id;
             private String name;
             private int daengleMeter;
-            private Proposal proposal;
-            private String image;
+            private String imageURL;
             private String shopName;
+            private List<GroomingKeyword> keywords;
 
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
             private LocalDateTime reservedDate;
         }
+    }
+
+    @Getter
+    @Builder
+    public static class Care {
+
+        private List<Content> estimates;
 
         @Getter
         @Builder
-        public static class Care {
-            private Long careEstimateId;
+        public static class Content {
+            private Long id;
             private String name;
             private int daengleMeter;
-            private Proposal proposal;
-            private String image;
+            private String imageURL;
+            private List<CareKeyword> keywords;
 
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
             private LocalDateTime reservedDate;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/dto/EstimateInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/dto/EstimateInfo.java
@@ -22,7 +22,8 @@ public class EstimateInfo {
         @Getter
         @Builder
         public static class Content {
-            private Long id;
+            private Long estimateId;
+            private Long petId;
             private String imageURL;
             private String name;
         }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/ModifyCareReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/ModifyCareReviewInfo.java
@@ -1,6 +1,6 @@
 package ddog.user.presentation.review.dto.request;
 
-import ddog.domain.review.enums.CareKeywordReview;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 public class ModifyCareReviewInfo {
     private Long starRating;
-    private List<CareKeywordReview> careKeywordReviewList;
+    private List<CareKeyword> careKeywordList;
     private String content;
     private List<String> imageUrlList;
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/ModifyGroomingReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/ModifyGroomingReviewInfo.java
@@ -1,6 +1,6 @@
 package ddog.user.presentation.review.dto.request;
 
-import ddog.domain.review.enums.GroomingKeywordReview;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 public class ModifyGroomingReviewInfo {
     private Long starRating;
-    private List<GroomingKeywordReview> groomingKeywordReviewList;
+    private List<GroomingKeyword> groomingKeywordList;
     private String content;
     private List<String> imageUrlList;
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/PostCareReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/PostCareReviewInfo.java
@@ -1,6 +1,6 @@
 package ddog.user.presentation.review.dto.request;
 
-import ddog.domain.review.enums.CareKeywordReview;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ import java.util.List;
 public class PostCareReviewInfo {
     private Long reservationId;
     private Long starRating;
-    private List<CareKeywordReview> careKeywordReviewList;
+    private List<CareKeyword> careKeywordList;
     private String content;
     private List<String> imageUrlList;
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/PostGroomingReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/PostGroomingReviewInfo.java
@@ -1,6 +1,6 @@
 package ddog.user.presentation.review.dto.request;
 
-import ddog.domain.review.enums.GroomingKeywordReview;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ import java.util.List;
 public class PostGroomingReviewInfo {
     private Long reservationId;
     private Long starRating;
-    private List<GroomingKeywordReview> groomingKeywordReviewList;
+    private List<GroomingKeyword> groomingKeywordList;
     private String content;
     private List<String> imageUrlList;
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/CareReviewDetailResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/CareReviewDetailResp.java
@@ -1,6 +1,6 @@
 package ddog.user.presentation.review.dto.response;
 
-import ddog.domain.review.enums.CareKeywordReview;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ import java.util.List;
 public class CareReviewDetailResp {
     private Long careReviewId;
     private Long vetId;
-    private List<CareKeywordReview> careKeywordReviewList;
+    private List<CareKeyword> careKeywordList;
     private String revieweeName;
     private String shopName;
     private double starRating;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/CareReviewSummaryResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/CareReviewSummaryResp.java
@@ -1,6 +1,6 @@
 package ddog.user.presentation.review.dto.response;
 
-import ddog.domain.review.enums.CareKeywordReview;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,9 +11,9 @@ import java.util.List;
 public class CareReviewSummaryResp {
     private Long careReviewId;
     private Long vetId;
+    private List<CareKeyword> careKeywordList;
     private String reviewerName;
     private String reviewerImageUrl;
-    private List<CareKeywordReview> careKeywordReviewList;
     private String revieweeName;
     private double starRating;
     private String content;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/GroomingReviewDetailResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/GroomingReviewDetailResp.java
@@ -1,6 +1,6 @@
 package ddog.user.presentation.review.dto.response;
 
-import ddog.domain.review.enums.GroomingKeywordReview;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ import java.util.List;
 public class GroomingReviewDetailResp {
     private Long groomingReviewId;
     private Long groomerId;
-    private List<GroomingKeywordReview> groomingKeywordReviewList;
+    private List<GroomingKeyword> groomingKeywordList;
     private String revieweeName;
     private String shopName;
     private double starRating;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/GroomingReviewSummaryResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/GroomingReviewSummaryResp.java
@@ -1,6 +1,6 @@
 package ddog.user.presentation.review.dto.response;
 
-import ddog.domain.review.enums.GroomingKeywordReview;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,9 +11,9 @@ import java.util.List;
 public class GroomingReviewSummaryResp {
     private Long groomingReviewId;
     private Long groomerId;
+    private List<GroomingKeyword> groomingKeywordList;
     private String reviewerName;
     private String reviewerImageUrl;
-    private List<GroomingKeywordReview> groomingKeywordReviewList;
     private String revieweeName;
     private double starRating;
     private String content;

--- a/daengle-vet-api/src/main/java/ddog/vet/application/EstimateService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/EstimateService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -42,16 +41,11 @@ public class EstimateService {
         List<CareEstimate> generalEstimates = careEstimatePersist.findCareEstimatesByAddress(vet.getAddress());
         List<CareEstimate> designationEstimates = careEstimatePersist.findCareEstimatesByVetId(vet.getAccountId());
 
-        List<EstimateInfo.Content> allContents = convertEstimatesToContents(generalEstimates);
+        List<EstimateInfo.Content> generalContents = convertEstimatesToContents(generalEstimates);
         List<EstimateInfo.Content> designationContents = convertEstimatesToContents(designationEstimates);
 
-        allContents.addAll(designationContents);
-
-        // estimateId 기준으로 오름차순 정렬
-        allContents.sort(Comparator.comparing(EstimateInfo.Content::getId));
-
         return EstimateInfo.builder()
-                .allEstimates(allContents)
+                .generalEstimates(generalContents)
                 .designationEstimates(designationContents)
                 .build();
     }

--- a/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
@@ -38,7 +38,7 @@ public class ReviewService {
                 .map(careReview -> ReviewSummaryResp.builder()
                         .careReviewId(careReview.getCareReviewId())
                         .vetId(careReview.getVetId())
-                        .careKeywordReviewList(careReview.getCareKeywordReviewList())
+                        .careKeywordList(careReview.getCareKeywordList())
                         .revieweeName(careReview.getRevieweeName())
                         .starRating(careReview.getStarRating())
                         .content(careReview.getContent())

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/estimate/dto/EstimateInfo.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/estimate/dto/EstimateInfo.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Builder
 public class EstimateInfo {
 
-    List<Content> allEstimates;
+    List<Content> generalEstimates;
     List<Content> designationEstimates;
 
     @Getter

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/review/dto/ReviewSummaryResp.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/review/dto/ReviewSummaryResp.java
@@ -1,6 +1,6 @@
 package ddog.vet.presentation.review.dto;
 
-import ddog.domain.review.enums.CareKeywordReview;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ import java.util.List;
 public class ReviewSummaryResp {
     private Long careReviewId;
     private Long vetId;
-    private List<CareKeywordReview> careKeywordReviewList;
+    private List<CareKeyword> careKeywordList;
     private String revieweeName;
     private double starRating;
     private String content;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X
> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 기존 미용사, 병원 전체/지정 탭 -> 일반/지정 탭으로 전환
    - 견적서 페이지 접근시 견적서를 기다리는 반려동물의 정보만 가져오도록 기능 구현
    - 기존 사용자 미용/진료 견적서 조회 -> 미용/진료 일반, 지정 페이징 API 추가
    - 미용/진료 견적서 목록 조회 과정에서 사용자의 견적서 작성 여부 확인 후 반환 기능 추가
    - 기존 미용사/병원 견적서 조회 -> 일반/지정 페이징 API 추가
    - 기존 리뷰에 들어있는 태그 정보를 미용사, 병원 각각에게 할당하도록 데이터 속성값 위치 변경

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - Spring Data JPA 에서 제공하는 페이징 기법을 사용했는데, 직접 쿼리문을 작성한 것이 아니라 데이터가 올바르게 페이징돼서 들어오는지 검증하는 과정을 꼭 가져야 할 것 같습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : 기존 `Review` 테이블에 있던 `GroomingKeywordReview, CareKeywordReview` 의 위치를 `Groomer, Vet` 의 위치로 `GroomingKeyword, CareKeyword` 로 네이밍을 변경 후 옮김

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
