### PR TITLE
[feat/daengle-68] 리뷰 조회 API 응답값 일정(schedule) 추가 

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/review/port/CareReviewPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/port/CareReviewPersist.java
@@ -11,5 +11,6 @@ public interface CareReviewPersist {
     CareReview save(CareReview careReview);
     void delete(CareReview careReview);
     Page<CareReview> findByReviewerId(Long userId, Pageable pageable);
+    Page<CareReview> findByRevieweeId(Long userId, Pageable pageable);
     Page<CareReview> findByVetId(Long reviewerId, Pageable pageable);
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/ReviewService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/ReviewService.java
@@ -1,9 +1,17 @@
 package ddog.groomer.application;
 
 import ddog.domain.groomer.Groomer;
+import ddog.domain.payment.Reservation;
+import ddog.domain.payment.port.ReservationPersist;
 import ddog.domain.review.GroomingReview;
+import ddog.domain.user.User;
+import ddog.domain.user.port.UserPersist;
+import ddog.groomer.application.exception.GroomingReviewException;
+import ddog.groomer.application.exception.GroomingReviewExceptionType;
 import ddog.groomer.application.exception.account.GroomerException;
 import ddog.groomer.application.exception.account.GroomerExceptionType;
+import ddog.groomer.application.exception.account.UserException;
+import ddog.groomer.application.exception.account.UserExceptionType;
 import ddog.groomer.presentation.review.dto.ReviewListResp;
 import ddog.groomer.presentation.review.dto.ReviewSummaryResp;
 import ddog.domain.groomer.port.GroomerPersist;
@@ -22,7 +30,38 @@ import java.util.List;
 public class ReviewService {
 
     private final GroomingReviewPersist groomingReviewPersist;
+    private final ReservationPersist reservationPersist;
+    private final UserPersist userPersist;
     private final GroomerPersist groomerPersist;
+
+    private ReviewListResp mappingToGroomingReviewListResp(Page<GroomingReview> groomingReviews) {
+        List<ReviewSummaryResp> groomingReviewList = groomingReviews.stream().map(groomingReview -> {
+
+            User reviewer = userPersist.findByAccountId(groomingReview.getReviewerId())
+                    .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+            Reservation savedReservation = reservationPersist.findByReservationId(groomingReview.getReservationId())
+                    .orElseThrow(() -> new GroomingReviewException(GroomingReviewExceptionType.GROOMING_REVIEW_RESERVATION_NOT_FOUND));
+
+            return ReviewSummaryResp.builder()
+                    .groomingReviewId(groomingReview.getGroomingReviewId())
+                    .reviewerName(reviewer.getNickname())
+                    .reviewerImageUrl(reviewer.getUserImage())
+                    .groomerId(groomingReview.getGroomerId())
+                    .groomingKeywordList(groomingReview.getGroomingKeywordList())
+                    .revieweeName(groomingReview.getRevieweeName())
+                    .schedule(savedReservation.getSchedule())
+                    .starRating(groomingReview.getStarRating())
+                    .content(groomingReview.getContent())
+                    .imageUrlList(groomingReview.getImageUrlList())
+                    .build();
+        }).toList();    //groomingReviewList
+
+        return ReviewListResp.builder()
+                .reviewCount(groomingReviews.getTotalElements())
+                .reviewList(groomingReviewList)
+                .build();
+    }
 
     public ReviewListResp findReviewList(Long accountId, int page, int size) {
         Groomer savedGroomer = groomerPersist.findByAccountId(accountId)
@@ -32,24 +71,5 @@ public class ReviewService {
         Page<GroomingReview> groomingReviews = groomingReviewPersist.findByGroomerId(savedGroomer.getGroomerId(), pageable);
 
         return mappingToGroomingReviewListResp(groomingReviews);
-    }
-
-    private static ReviewListResp mappingToGroomingReviewListResp(Page<GroomingReview> groomingReviews) {
-        List<ReviewSummaryResp> groomingReviewList = groomingReviews.stream()
-                .map(groomingReview -> ReviewSummaryResp.builder()
-                        .groomingReviewId(groomingReview.getGroomingReviewId())
-                        .groomerId(groomingReview.getGroomerId())
-                        .groomingKeywordList(groomingReview.getGroomingKeywordList())
-                        .revieweeName(groomingReview.getRevieweeName())
-                        .starRating(groomingReview.getStarRating())
-                        .content(groomingReview.getContent())
-                        .imageUrlList(groomingReview.getImageUrlList())
-                        .build())
-                .toList();
-
-        return ReviewListResp.builder()
-                .reviewCount(groomingReviews.getTotalElements())
-                .reviewList(groomingReviewList)
-                .build();
     }
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/GroomingReviewException.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/GroomingReviewException.java
@@ -1,0 +1,9 @@
+package ddog.groomer.application.exception;
+
+import ddog.auth.exception.common.CustomRuntimeException;
+
+public class GroomingReviewException extends CustomRuntimeException {
+    public GroomingReviewException(GroomingReviewExceptionType type, Object... args) {
+        super(type.getMessage(), type.getHttpStatus(), type.getCode());
+    }
+}

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/GroomingReviewExceptionType.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/GroomingReviewExceptionType.java
@@ -1,0 +1,25 @@
+package ddog.groomer.application.exception;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum GroomingReviewExceptionType {
+    GROOMING_REVIEW_RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "미용 예약이 존재하지 않음.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public Integer getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/review/dto/ReviewSummaryResp.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/review/dto/ReviewSummaryResp.java
@@ -4,6 +4,7 @@ import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -12,7 +13,10 @@ public class ReviewSummaryResp {
     private Long groomingReviewId;
     private Long groomerId;
     private List<GroomingKeyword> groomingKeywordList;
+    private String reviewerName;
+    private String reviewerImageUrl;
     private String revieweeName;
+    private LocalDateTime schedule;
     private double starRating;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareReviewRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareReviewRepository.java
@@ -39,6 +39,11 @@ public class CareReviewRepository implements CareReviewPersist {
     }
 
     @Override
+    public Page<CareReview> findByRevieweeId(Long userId, Pageable pageable) {
+        return careReviewJpaRepository.findByRevieweeId(userId, pageable).map(CareReviewJpaEntity::toModel);
+    }
+
+    @Override
     public Page<CareReview> findByVetId(Long vetId, Pageable pageable) {
         return careReviewJpaRepository.findByVetId(vetId, pageable).map(CareReviewJpaEntity::toModel);
     }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareReviewJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareReviewJpaRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 
 public interface CareReviewJpaRepository extends JpaRepository<CareReviewJpaEntity, Long> {
     Page<CareReviewJpaEntity> findByReviewerId(Long reviewerId, Pageable pageable);
+    Page<CareReviewJpaEntity> findByRevieweeId(Long reviewerId, Pageable pageable);
     Page<CareReviewJpaEntity> findByVetId(Long vetId, Pageable pageable);
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
@@ -43,6 +43,27 @@ public class CareReviewService {
 
     private final BadWordFiltering badWordFiltering;
 
+    @Transactional(readOnly = true)
+    public CareReviewDetailResp findReview(Long reviewId) {
+        CareReview savedCareReview = careReviewPersist.findByReviewId(reviewId)
+                .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
+
+        Reservation savedReservation = reservationPersist.findByReservationId(savedCareReview.getReservationId())
+                .orElseThrow(() -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
+
+        return CareReviewDetailResp.builder()
+                .careReviewId(savedCareReview.getCareReviewId())
+                .vetId(savedCareReview.getVetId())
+                .careKeywordReviewList(savedCareReview.getCareKeywordReviewList())
+                .revieweeName(savedCareReview.getRevieweeName())
+                .shopName(savedCareReview.getShopName())
+                .starRating(savedCareReview.getStarRating())
+                .schedule(savedReservation.getSchedule())
+                .content(savedCareReview.getContent())
+                .imageUrlList(savedCareReview.getImageUrlList())
+                .build();
+    }
+
     @Transactional
     public ReviewResp postReview(PostCareReviewInfo postCareReviewInfo) {
         Reservation reservation = reservationPersist.findByReservationId(postCareReviewInfo.getReservationId()).orElseThrow(()
@@ -98,23 +119,6 @@ public class CareReviewService {
     }
 
     @Transactional(readOnly = true)
-    public CareReviewDetailResp findReview(Long reviewId) {
-        CareReview savedCareReview = careReviewPersist.findByReviewId(reviewId)
-                .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
-
-        return CareReviewDetailResp.builder()
-                .careReviewId(savedCareReview.getCareReviewId())
-                .vetId(savedCareReview.getVetId())
-                .careKeywordList(savedCareReview.getCareKeywordList())
-                .revieweeName(savedCareReview.getRevieweeName())
-                .shopName(savedCareReview.getShopName())
-                .starRating(savedCareReview.getStarRating())
-                .content(savedCareReview.getContent())
-                .imageUrlList(savedCareReview.getImageUrlList())
-                .build();
-    }
-
-    @Transactional(readOnly = true)
     public CareReviewListResp findMyReviewList(Long accountId, int page, int size) {
         User savedUser = userPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
@@ -137,14 +141,14 @@ public class CareReviewService {
 
     private void validatePostCareReviewInfoDataFormat(PostCareReviewInfo postCareReviewInfo) {
         CareReview.validateStarRating(postCareReviewInfo.getStarRating());
-        CareReview.validateCareKeywordReviewList(postCareReviewInfo.getCareKeywordList());
+        CareReview.validateCareKeywordReviewList(postCareReviewInfo.getCareKeywordReviewList());
         CareReview.validateContent(postCareReviewInfo.getContent());
         CareReview.validateImageUrlList(postCareReviewInfo.getImageUrlList());
     }
 
     private void validateModifyCareReviewInfoDataFormat(ModifyCareReviewInfo modifyCareReviewInfo) {
         CareReview.validateStarRating(modifyCareReviewInfo.getStarRating());
-        CareReview.validateCareKeywordReviewList(modifyCareReviewInfo.getCareKeywordList());
+        CareReview.validateCareKeywordReviewList(modifyCareReviewInfo.getCareKeywordReviewList());
         CareReview.validateContent(modifyCareReviewInfo.getContent());
         CareReview.validateImageUrlList(modifyCareReviewInfo.getImageUrlList());
     }
@@ -160,7 +164,7 @@ public class CareReviewService {
                     .reviewerName(reviewer.getUsername())
                     .reviewerImageUrl(reviewer.getUserImage())
                     .vetId(careReview.getVetId())
-                    .careKeywordList(careReview.getCareKeywordList())
+                    .careKeywordReviewList(careReview.getCareKeywordReviewList())
                     .revieweeName(careReview.getRevieweeName())
                     .starRating(careReview.getStarRating())
                     .content(careReview.getContent())

--- a/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
@@ -54,7 +54,7 @@ public class CareReviewService {
         return CareReviewDetailResp.builder()
                 .careReviewId(savedCareReview.getCareReviewId())
                 .vetId(savedCareReview.getVetId())
-                .careKeywordReviewList(savedCareReview.getCareKeywordReviewList())
+                .careKeywordList(savedCareReview.getCareKeywordList())
                 .revieweeName(savedCareReview.getRevieweeName())
                 .shopName(savedCareReview.getShopName())
                 .starRating(savedCareReview.getStarRating())
@@ -141,14 +141,14 @@ public class CareReviewService {
 
     private void validatePostCareReviewInfoDataFormat(PostCareReviewInfo postCareReviewInfo) {
         CareReview.validateStarRating(postCareReviewInfo.getStarRating());
-        CareReview.validateCareKeywordReviewList(postCareReviewInfo.getCareKeywordReviewList());
+        CareReview.validateCareKeywordReviewList(postCareReviewInfo.getCareKeywordList());
         CareReview.validateContent(postCareReviewInfo.getContent());
         CareReview.validateImageUrlList(postCareReviewInfo.getImageUrlList());
     }
 
     private void validateModifyCareReviewInfoDataFormat(ModifyCareReviewInfo modifyCareReviewInfo) {
         CareReview.validateStarRating(modifyCareReviewInfo.getStarRating());
-        CareReview.validateCareKeywordReviewList(modifyCareReviewInfo.getCareKeywordReviewList());
+        CareReview.validateCareKeywordReviewList(modifyCareReviewInfo.getCareKeywordList());
         CareReview.validateContent(modifyCareReviewInfo.getContent());
         CareReview.validateImageUrlList(modifyCareReviewInfo.getImageUrlList());
     }
@@ -159,13 +159,17 @@ public class CareReviewService {
             User reviewer = userPersist.findByAccountId(careReview.getReviewerId())
                     .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
 
+            Reservation savedReservation = reservationPersist.findByReservationId(careReview.getReservationId())
+                    .orElseThrow(() -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
+
             return CareReviewSummaryResp.builder()
                     .careReviewId(careReview.getCareReviewId())
                     .reviewerName(reviewer.getUsername())
                     .reviewerImageUrl(reviewer.getUserImage())
                     .vetId(careReview.getVetId())
-                    .careKeywordReviewList(careReview.getCareKeywordReviewList())
+                    .careKeywordList(careReview.getCareKeywordList())
                     .revieweeName(careReview.getRevieweeName())
+                    .schedule(savedReservation.getSchedule())
                     .starRating(careReview.getStarRating())
                     .content(careReview.getContent())
                     .imageUrlList(careReview.getImageUrlList())

--- a/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
@@ -55,7 +55,7 @@ public class GroomingReviewService {
         return GroomingReviewDetailResp.builder()
                 .groomingReviewId(savedGroomingReview.getGroomingReviewId())
                 .groomerId(savedGroomingReview.getGroomerId())
-                .groomingKeywordReviewList(savedGroomingReview.getGroomingKeywordReviewList())
+                .groomingKeywordList(savedGroomingReview.getGroomingKeywordList())
                 .revieweeName(savedGroomingReview.getRevieweeName())
                 .shopName(savedGroomingReview.getShopName())
                 .starRating(savedGroomingReview.getStarRating())
@@ -146,14 +146,14 @@ public class GroomingReviewService {
 
     private void validatePostGroomingReviewInfoDataFormat(PostGroomingReviewInfo postGroomingReviewInfo) {
         GroomingReview.validateStarRating(postGroomingReviewInfo.getStarRating());
-        GroomingReview.validateGroomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList());
+        GroomingReview.validateGroomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordList());
         GroomingReview.validateContent(postGroomingReviewInfo.getContent());
         GroomingReview.validateImageUrlList(postGroomingReviewInfo.getImageUrlList());
     }
 
     private void validateModifyGroomingReviewInfoDataFormat(UpdateGroomingReviewInfo updateGroomingReviewInfo) {
         GroomingReview.validateStarRating(updateGroomingReviewInfo.getStarRating());
-        GroomingReview.validateGroomingKeywordReviewList(updateGroomingReviewInfo.getGroomingKeywordReviewList());
+        GroomingReview.validateGroomingKeywordReviewList(updateGroomingReviewInfo.getGroomingKeywordList());
         GroomingReview.validateContent(updateGroomingReviewInfo.getContent());
         GroomingReview.validateImageUrlList(updateGroomingReviewInfo.getImageUrlList());
     }
@@ -164,13 +164,17 @@ public class GroomingReviewService {
             User reviewer = userPersist.findByAccountId(groomingReview.getReviewerId())
                     .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
 
+            Reservation savedReservation = reservationPersist.findByReservationId(groomingReview.getReservationId()).orElseThrow(()
+                    -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
+
             return GroomingReviewSummaryResp.builder()
                     .groomingReviewId(groomingReview.getGroomingReviewId())
                     .reviewerName(reviewer.getUsername())
                     .reviewerImageUrl(reviewer.getUserImage())
                     .groomerId(groomingReview.getGroomerId())
-                    .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
+                    .groomingKeywordList(groomingReview.getGroomingKeywordList())
                     .revieweeName(groomingReview.getRevieweeName())
+                    .schedule(savedReservation.getSchedule())
                     .starRating(groomingReview.getStarRating())
                     .content(groomingReview.getContent())
                     .imageUrlList(groomingReview.getImageUrlList())

--- a/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
@@ -4,7 +4,7 @@ import com.vane.badwordfiltering.BadWordFiltering;
 import ddog.domain.groomer.Groomer;
 import ddog.domain.payment.Reservation;
 import ddog.domain.review.GroomingReview;
-import ddog.user.presentation.review.dto.request.ModifyGroomingReviewInfo;
+import ddog.user.presentation.review.dto.request.UpdateGroomingReviewInfo;
 import ddog.user.presentation.review.dto.request.PostGroomingReviewInfo;
 import ddog.domain.user.User;
 import ddog.domain.groomer.port.GroomerPersist;
@@ -44,6 +44,27 @@ public class GroomingReviewService {
 
     private final BadWordFiltering badWordFiltering;
 
+    @Transactional(readOnly = true)
+    public GroomingReviewDetailResp findReview(Long reviewId) {
+        GroomingReview savedGroomingReview = groomingReviewPersist.findByReviewId(reviewId)
+                .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
+
+        Reservation savedReservation = reservationPersist.findByReservationId(savedGroomingReview.getReservationId())
+                .orElseThrow(() -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
+
+        return GroomingReviewDetailResp.builder()
+                .groomingReviewId(savedGroomingReview.getGroomingReviewId())
+                .groomerId(savedGroomingReview.getGroomerId())
+                .groomingKeywordReviewList(savedGroomingReview.getGroomingKeywordReviewList())
+                .revieweeName(savedGroomingReview.getRevieweeName())
+                .shopName(savedGroomingReview.getShopName())
+                .starRating(savedGroomingReview.getStarRating())
+                .schedule(savedReservation.getSchedule())
+                .content(savedGroomingReview.getContent())
+                .imageUrlList(savedGroomingReview.getImageUrlList())
+                .build();
+    }
+
     @Transactional
     public ReviewResp postReview(PostGroomingReviewInfo postGroomingReviewInfo) {
         Reservation reservation = reservationPersist.findByReservationId(postGroomingReviewInfo.getReservationId()).orElseThrow(()
@@ -65,14 +86,15 @@ public class GroomingReviewService {
     }
 
     @Transactional
-    public ReviewResp updateReview(Long reviewId, ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
+    public ReviewResp updateReview(Long reviewId, UpdateGroomingReviewInfo updateGroomingReviewInfo) {
         GroomingReview savedGroomingReview = groomingReviewPersist.findByReviewId(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
 
-        if(isContainBanWord(modifyGroomingReviewInfo.getContent())) throw new ReviewException(ReviewExceptionType.REVIEW_CONTENT_CONTAIN_BAN_WORD);
-        validateModifyGroomingReviewInfoDataFormat(modifyGroomingReviewInfo);
+        if(isContainBanWord(updateGroomingReviewInfo.getContent())) throw new ReviewException(ReviewExceptionType.REVIEW_CONTENT_CONTAIN_BAN_WORD);
 
-        GroomingReview modifiedReview = GroomingReviewMapper.modifyBy(savedGroomingReview, modifyGroomingReviewInfo);
+        validateModifyGroomingReviewInfoDataFormat(updateGroomingReviewInfo);
+
+        GroomingReview modifiedReview = GroomingReviewMapper.updateBy(savedGroomingReview, updateGroomingReviewInfo);
         GroomingReview updatedGroomingReview = groomingReviewPersist.save(modifiedReview);
 
         //TODO 댕글미터 재계산해서 영속
@@ -101,23 +123,6 @@ public class GroomingReviewService {
     }
 
     @Transactional(readOnly = true)
-    public GroomingReviewDetailResp findReview(Long reviewId) {
-        GroomingReview savedGroomingReview = groomingReviewPersist.findByReviewId(reviewId)
-                .orElseThrow(() -> new ReviewException(ReviewExceptionType.REVIEW_NOT_FOUND));
-
-        return GroomingReviewDetailResp.builder()
-                .groomingReviewId(savedGroomingReview.getGroomingReviewId())
-                .groomerId(savedGroomingReview.getGroomerId())
-                .groomingKeywordList(savedGroomingReview.getGroomingKeywordList())
-                .revieweeName(savedGroomingReview.getRevieweeName())
-                .shopName(savedGroomingReview.getShopName())
-                .starRating(savedGroomingReview.getStarRating())
-                .content(savedGroomingReview.getContent())
-                .imageUrlList(savedGroomingReview.getImageUrlList())
-                .build();
-    }
-
-    @Transactional(readOnly = true)
     public GroomingReviewListResp findMyReviewList(Long accountId, int page, int size) {
         User savedUser = userPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
@@ -141,16 +146,16 @@ public class GroomingReviewService {
 
     private void validatePostGroomingReviewInfoDataFormat(PostGroomingReviewInfo postGroomingReviewInfo) {
         GroomingReview.validateStarRating(postGroomingReviewInfo.getStarRating());
-        GroomingReview.validateGroomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordList());
+        GroomingReview.validateGroomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList());
         GroomingReview.validateContent(postGroomingReviewInfo.getContent());
         GroomingReview.validateImageUrlList(postGroomingReviewInfo.getImageUrlList());
     }
 
-    private void validateModifyGroomingReviewInfoDataFormat(ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
-        GroomingReview.validateStarRating(modifyGroomingReviewInfo.getStarRating());
-        GroomingReview.validateGroomingKeywordReviewList(modifyGroomingReviewInfo.getGroomingKeywordList());
-        GroomingReview.validateContent(modifyGroomingReviewInfo.getContent());
-        GroomingReview.validateImageUrlList(modifyGroomingReviewInfo.getImageUrlList());
+    private void validateModifyGroomingReviewInfoDataFormat(UpdateGroomingReviewInfo updateGroomingReviewInfo) {
+        GroomingReview.validateStarRating(updateGroomingReviewInfo.getStarRating());
+        GroomingReview.validateGroomingKeywordReviewList(updateGroomingReviewInfo.getGroomingKeywordReviewList());
+        GroomingReview.validateContent(updateGroomingReviewInfo.getContent());
+        GroomingReview.validateImageUrlList(updateGroomingReviewInfo.getImageUrlList());
     }
 
     private GroomingReviewListResp mappingToGroomingReviewListResp(Page<GroomingReview> groomingReviews) {
@@ -164,7 +169,7 @@ public class GroomingReviewService {
                     .reviewerName(reviewer.getUsername())
                     .reviewerImageUrl(reviewer.getUserImage())
                     .groomerId(groomingReview.getGroomerId())
-                    .groomingKeywordList(groomingReview.getGroomingKeywordList())
+                    .groomingKeywordReviewList(groomingReview.getGroomingKeywordReviewList())
                     .revieweeName(groomingReview.getRevieweeName())
                     .starRating(groomingReview.getStarRating())
                     .content(groomingReview.getContent())

--- a/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
@@ -164,12 +164,12 @@ public class GroomingReviewService {
             User reviewer = userPersist.findByAccountId(groomingReview.getReviewerId())
                     .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
 
-            Reservation savedReservation = reservationPersist.findByReservationId(groomingReview.getReservationId()).orElseThrow(()
-                    -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
+            Reservation savedReservation = reservationPersist.findByReservationId(groomingReview.getReservationId())
+                    .orElseThrow(() -> new ReservationException(ReservationExceptionType.RESERVATION_NOT_FOUND));
 
             return GroomingReviewSummaryResp.builder()
                     .groomingReviewId(groomingReview.getGroomingReviewId())
-                    .reviewerName(reviewer.getUsername())
+                    .reviewerName(reviewer.getNickname())
                     .reviewerImageUrl(reviewer.getUserImage())
                     .groomerId(groomingReview.getGroomerId())
                     .groomingKeywordList(groomingReview.getGroomingKeywordList())

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingReviewMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingReviewMapper.java
@@ -20,7 +20,7 @@ public class GroomingReviewMapper {
                 .content(postGroomingReviewInfo.getContent())
                 .createTime(LocalDateTime.now())
                 .imageUrlList(postGroomingReviewInfo.getImageUrlList())
-                .groomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList())
+                .groomingKeywordList(postGroomingReviewInfo.getGroomingKeywordList())
                 .build();
     }
 
@@ -37,7 +37,7 @@ public class GroomingReviewMapper {
                 .createTime(groomingReview.getCreateTime())
                 .modifiedTime(LocalDateTime.now())
                 .imageUrlList(updateGroomingReviewInfo.getImageUrlList())
-                .groomingKeywordReviewList(updateGroomingReviewInfo.getGroomingKeywordReviewList())
+                .groomingKeywordList(updateGroomingReviewInfo.getGroomingKeywordList())
                 .build();
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingReviewMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingReviewMapper.java
@@ -2,7 +2,7 @@ package ddog.user.application.mapper;
 
 import ddog.domain.payment.Reservation;
 import ddog.domain.review.GroomingReview;
-import ddog.user.presentation.review.dto.request.ModifyGroomingReviewInfo;
+import ddog.user.presentation.review.dto.request.UpdateGroomingReviewInfo;
 import ddog.user.presentation.review.dto.request.PostGroomingReviewInfo;
 
 import java.time.LocalDateTime;
@@ -20,11 +20,11 @@ public class GroomingReviewMapper {
                 .content(postGroomingReviewInfo.getContent())
                 .createTime(LocalDateTime.now())
                 .imageUrlList(postGroomingReviewInfo.getImageUrlList())
-                .groomingKeywordList(postGroomingReviewInfo.getGroomingKeywordList())
+                .groomingKeywordReviewList(postGroomingReviewInfo.getGroomingKeywordReviewList())
                 .build();
     }
 
-    public static GroomingReview modifyBy(GroomingReview groomingReview, ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
+    public static GroomingReview updateBy(GroomingReview groomingReview, UpdateGroomingReviewInfo updateGroomingReviewInfo) {
         return GroomingReview.builder()
                 .groomingReviewId(groomingReview.getGroomingReviewId())
                 .reservationId(groomingReview.getReservationId())
@@ -32,12 +32,12 @@ public class GroomingReviewMapper {
                 .groomerId(groomingReview.getGroomerId())
                 .revieweeName(groomingReview.getRevieweeName())
                 .shopName(groomingReview.getShopName())
-                .starRating(modifyGroomingReviewInfo.getStarRating())
-                .content(modifyGroomingReviewInfo.getContent())
+                .starRating(updateGroomingReviewInfo.getStarRating())
+                .content(updateGroomingReviewInfo.getContent())
                 .createTime(groomingReview.getCreateTime())
                 .modifiedTime(LocalDateTime.now())
-                .imageUrlList(modifyGroomingReviewInfo.getImageUrlList())
-                .groomingKeywordList(groomingReview.getGroomingKeywordList())
+                .imageUrlList(updateGroomingReviewInfo.getImageUrlList())
+                .groomingKeywordReviewList(updateGroomingReviewInfo.getGroomingKeywordReviewList())
                 .build();
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/CareReviewController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/CareReviewController.java
@@ -20,14 +20,14 @@ public class CareReviewController {
 
     private final CareReviewService careReviewService;
 
-    @PostMapping("/care/review")
-    public CommonResponseEntity<ReviewResp> postReview(@RequestBody PostCareReviewInfo postCareReviewInfo) {
-        return success(careReviewService.postReview(postCareReviewInfo));
-    }
-
     @GetMapping("/care/review/{reviewId}")
     public CommonResponseEntity<CareReviewDetailResp> findReview(@PathVariable Long reviewId) {
         return success(careReviewService.findReview(reviewId));
+    }
+
+    @PostMapping("/care/review")
+    public CommonResponseEntity<ReviewResp> postReview(@RequestBody PostCareReviewInfo postCareReviewInfo) {
+        return success(careReviewService.postReview(postCareReviewInfo));
     }
 
     @PatchMapping("care/review/{reviewId}")

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/GroomingReviewController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/GroomingReviewController.java
@@ -2,17 +2,14 @@ package ddog.user.presentation.review;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
-import ddog.user.presentation.review.dto.request.ModifyGroomingReviewInfo;
+import ddog.user.presentation.review.dto.request.UpdateGroomingReviewInfo;
 import ddog.user.presentation.review.dto.request.PostGroomingReviewInfo;
 import ddog.user.application.GroomingReviewService;
 import ddog.user.presentation.review.dto.response.GroomingReviewDetailResp;
 import ddog.user.presentation.review.dto.response.GroomingReviewListResp;
-import ddog.user.presentation.review.dto.response.GroomingReviewSummaryResp;
 import ddog.user.presentation.review.dto.response.ReviewResp;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static ddog.auth.exception.common.CommonResponseEntity.success;
 
@@ -23,20 +20,20 @@ public class GroomingReviewController {
 
     private final GroomingReviewService groomingReviewService;
 
-    @PostMapping("/grooming/review")
-    public CommonResponseEntity<ReviewResp> postReview(@RequestBody PostGroomingReviewInfo postGroomingReviewInfo) {
-        return success(groomingReviewService.postReview(postGroomingReviewInfo));
-    }
-
     @GetMapping("/grooming/review/{reviewId}")
     public CommonResponseEntity<GroomingReviewDetailResp> findReview(@PathVariable Long reviewId) {
         return success(groomingReviewService.findReview(reviewId));
     }
 
+    @PostMapping("/grooming/review")
+    public CommonResponseEntity<ReviewResp> postReview(@RequestBody PostGroomingReviewInfo postGroomingReviewInfo) {
+        return success(groomingReviewService.postReview(postGroomingReviewInfo));
+    }
+
     @PatchMapping("/grooming/review/{reviewId}")
     public CommonResponseEntity<ReviewResp> updateReview(@PathVariable Long reviewId,
-                                                         @RequestBody ModifyGroomingReviewInfo modifyGroomingReviewInfo) {
-        return success(groomingReviewService.updateReview(reviewId, modifyGroomingReviewInfo));
+                                                         @RequestBody UpdateGroomingReviewInfo updateGroomingReviewInfo) {
+        return success(groomingReviewService.updateReview(reviewId, updateGroomingReviewInfo));
     }
 
     @DeleteMapping("/grooming/review/{reviewId}")

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/UpdateGroomingReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/UpdateGroomingReviewInfo.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Builder
 @Getter
-public class ModifyGroomingReviewInfo {
+public class UpdateGroomingReviewInfo {
     private Long starRating;
     private List<GroomingKeyword> groomingKeywordList;
     private String content;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/CareReviewDetailResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/CareReviewDetailResp.java
@@ -4,6 +4,7 @@ import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
@@ -14,6 +15,7 @@ public class CareReviewDetailResp {
     private List<CareKeyword> careKeywordList;
     private String revieweeName;
     private String shopName;
+    private LocalDateTime schedule;
     private double starRating;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/CareReviewSummaryResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/CareReviewSummaryResp.java
@@ -4,6 +4,7 @@ import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
@@ -15,6 +16,7 @@ public class CareReviewSummaryResp {
     private String reviewerName;
     private String reviewerImageUrl;
     private String revieweeName;
+    private LocalDateTime schedule;
     private double starRating;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/GroomingReviewDetailResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/GroomingReviewDetailResp.java
@@ -4,6 +4,7 @@ import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
@@ -14,6 +15,7 @@ public class GroomingReviewDetailResp {
     private List<GroomingKeyword> groomingKeywordList;
     private String revieweeName;
     private String shopName;
+    private LocalDateTime schedule;
     private double starRating;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/GroomingReviewSummaryResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/response/GroomingReviewSummaryResp.java
@@ -4,6 +4,8 @@ import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
@@ -15,6 +17,7 @@ public class GroomingReviewSummaryResp {
     private String reviewerName;
     private String reviewerImageUrl;
     private String revieweeName;
+    private LocalDateTime schedule;
     private double starRating;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
@@ -1,14 +1,23 @@
 package ddog.vet.application;
 
+import ddog.domain.payment.Reservation;
+import ddog.domain.payment.port.ReservationPersist;
 import ddog.domain.review.CareReview;
+import ddog.domain.user.User;
+import ddog.domain.user.port.UserPersist;
 import ddog.domain.vet.Vet;
 import ddog.domain.review.port.CareReviewPersist;
 import ddog.domain.vet.port.VetPersist;
+import ddog.vet.application.exception.CareReviewException;
+import ddog.vet.application.exception.CareReviewExceptionType;
+import ddog.vet.application.exception.account.UserException;
+import ddog.vet.application.exception.account.UserExceptionType;
 import ddog.vet.application.exception.account.VetException;
 import ddog.vet.application.exception.account.VetExceptionType;
 import ddog.vet.presentation.review.dto.ReviewListResp;
 import ddog.vet.presentation.review.dto.ReviewSummaryResp;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -16,11 +25,14 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
 
     private final CareReviewPersist careReviewPersist;
+    private final ReservationPersist reservationPersist;
+    private final UserPersist userPersist;
     private final VetPersist vetPersist;
 
     public ReviewListResp findReviewList(Long accountId, int page, int size) {
@@ -28,23 +40,34 @@ public class ReviewService {
                 .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<CareReview> careReviews = careReviewPersist.findByVetId(savedVet.getVetId(), pageable);
+        Page<CareReview> careReviews = careReviewPersist.findByRevieweeId(savedVet.getAccountId(), pageable);
 
         return mappingToCareReviewListResp(careReviews);
     }
 
-    private static ReviewListResp mappingToCareReviewListResp(Page<CareReview> careReviews) {
-        List<ReviewSummaryResp> careReviewList = careReviews.stream()
-                .map(careReview -> ReviewSummaryResp.builder()
-                        .careReviewId(careReview.getCareReviewId())
-                        .vetId(careReview.getVetId())
-                        .careKeywordList(careReview.getCareKeywordList())
-                        .revieweeName(careReview.getRevieweeName())
-                        .starRating(careReview.getStarRating())
-                        .content(careReview.getContent())
-                        .imageUrlList(careReview.getImageUrlList())
-                        .build())
-                .toList();
+    private ReviewListResp mappingToCareReviewListResp(Page<CareReview> careReviews) {
+        List<ReviewSummaryResp> careReviewList = careReviews.stream().map(careReview -> {
+
+            User reviewer = userPersist.findByAccountId(careReview.getReviewerId())
+                    .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+            Reservation savedReservation = reservationPersist.findByReservationId(careReview.getReservationId())
+                    .orElseThrow(() -> new CareReviewException(CareReviewExceptionType.CARE_REVIEW_RESERVATION_NOT_FOUND));
+
+            return ReviewSummaryResp.builder()
+                    .careReviewId(careReview.getCareReviewId())
+                    .reviewerName(reviewer.getNickname())
+                    .reviewerImageUrl(reviewer.getUserImage())
+                    .vetId(careReview.getVetId())
+                    .careKeywordList(careReview.getCareKeywordList())
+                    .revieweeName(careReview.getRevieweeName())
+                    .schedule(savedReservation.getSchedule())
+                    .starRating(careReview.getStarRating())
+                    .content(careReview.getContent())
+                    .imageUrlList(careReview.getImageUrlList())
+                    .build();
+
+        }).toList();
 
         return ReviewListResp.builder()
                 .reviewCount(careReviews.getTotalElements())

--- a/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
@@ -66,8 +66,7 @@ public class ReviewService {
                     .content(careReview.getContent())
                     .imageUrlList(careReview.getImageUrlList())
                     .build();
-
-        }).toList();
+        }).toList();    //careReviewList
 
         return ReviewListResp.builder()
                 .reviewCount(careReviews.getTotalElements())

--- a/daengle-vet-api/src/main/java/ddog/vet/application/exception/CareReviewException.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/exception/CareReviewException.java
@@ -1,0 +1,10 @@
+package ddog.vet.application.exception;
+
+
+import ddog.auth.exception.common.CustomRuntimeException;
+
+public class CareReviewException extends CustomRuntimeException {
+    public CareReviewException(CareReviewExceptionType type, Object... args) {
+        super(type.getMessage(), type.getHttpStatus(), type.getCode());
+    }
+}

--- a/daengle-vet-api/src/main/java/ddog/vet/application/exception/CareReviewExceptionType.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/exception/CareReviewExceptionType.java
@@ -1,0 +1,25 @@
+package ddog.vet.application.exception;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum CareReviewExceptionType {
+    CARE_REVIEW_RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "진료 예약이 존재하지 않음.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public Integer getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/review/dto/ReviewSummaryResp.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/review/dto/ReviewSummaryResp.java
@@ -4,6 +4,7 @@ import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -12,7 +13,10 @@ public class ReviewSummaryResp {
     private Long careReviewId;
     private Long vetId;
     private List<CareKeyword> careKeywordList;
+    private String reviewerName;
+    private String reviewerImageUrl;
     private String revieweeName;
+    private LocalDateTime schedule;
     private double starRating;
     private String content;
     private List<String> imageUrlList;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 리뷰 조회 API 응답값에 서비스 일정 값을 추가했습니다

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 이건 마치 프론트에게는 '이 왼쪽 버튼 오른쪽으로 옮겨주세요'와 같은 것...
    - API 총 6개의 한 줄이 바뀐거지만 반나절 작업했습니다...이제 전 부하테스트하러 진짜 떠납니다

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
