### PR TITLE
[feat/daengle-71] 사용자 예약 견적서 페이징 조회 및 견적서 상세 조회 API 구현

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/payment/Order.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Order.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 public class Order {
 
     private Long orderId;
+    private Long petId;
     private ServiceType serviceType;
     private Long price;
     private Long estimateId;

--- a/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
@@ -31,7 +31,6 @@ public class Reservation {
     private String visitorName;
     private String visitorPhoneNumber;
     private Long paymentId;
-    private Long petId;
 
     public static void validateShopName(String shopName) {
         if (shopName == null || !shopName.matches("^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9\\s]{0,19}$")) {

--- a/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 public class Reservation {
     private Long reservationId;
     private Long estimateId;
+    private Long petId;
     private ServiceType serviceType;
     private ReservationStatus reservationStatus;
     private Long recipientId;

--- a/daengle-domain/src/main/java/ddog/domain/payment/port/ReservationPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/port/ReservationPersist.java
@@ -1,6 +1,7 @@
 package ddog.domain.payment.port;
 
 import ddog.domain.payment.Reservation;
+import ddog.domain.payment.enums.ReservationStatus;
 import ddog.domain.payment.enums.ServiceType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,9 +12,15 @@ import java.util.Optional;
 
 public interface ReservationPersist {
     Reservation save(Reservation reservation);
+
     Optional<Reservation> findByReservationId(Long reservationId);
+
     Page<Reservation> findPaymentHistoryList(Long accountId, ServiceType serviceType, Pageable pageable);
-    List<Reservation> findTodayCareReservationByPartnerId(LocalDateTime dateTime, ServiceType serviceType, Long recipientId) ;
-    List<Reservation> findTodayGroomingReservationByPartnerId(LocalDateTime dateTime, ServiceType serviceType, Long recipientId) ;
+
+    List<Reservation> findByTypeAndStatusAndCustomerId(ServiceType serviceType, ReservationStatus status, Long accountId);
+
+    List<Reservation> findTodayCareReservationByPartnerId(LocalDateTime dateTime, ServiceType serviceType, Long recipientId);
+
+    List<Reservation> findTodayGroomingReservationByPartnerId(LocalDateTime dateTime, ServiceType serviceType, Long recipientId);
 
 }

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/OrderMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/OrderMapper.java
@@ -12,6 +12,7 @@ public class OrderMapper {
     public static Order createBy(Long accountId, PostOrderInfo postOrderInfo, Payment payment) {
         return Order.builder()
                 .serviceType(postOrderInfo.getServiceType())
+                .petId(postOrderInfo.getPetId())
                 .price(postOrderInfo.getPrice())
                 .estimateId(postOrderInfo.getEstimateId())
                 .orderUid(String.valueOf(UUID.randomUUID()))

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/ReservationMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/ReservationMapper.java
@@ -10,6 +10,7 @@ public class ReservationMapper {
     public static Reservation createBy(Order order, Payment payment) {
         return Reservation.builder()
                 .estimateId(order.getEstimateId())
+                .petId(order.getPetId())
                 .serviceType(order.getServiceType())
                 .reservationStatus(ReservationStatus.DEPOSIT_PAID)
                 .recipientId(order.getRecipientId())  //수의사 or 병원 PK

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 public class PostOrderInfo {
     private Long estimateId;
+    private Long petId;
     private ServiceType serviceType;
     private Long recipientId;
     private String recipientImageUrl;

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
@@ -22,5 +22,4 @@ public class PostOrderInfo {
     private String customerPhoneNumber;
     private String visitorName;
     private String visitorPhoneNumber;
-    private Long petId;
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/ReservationRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/ReservationRepository.java
@@ -3,14 +3,15 @@ package ddog.persistence.mysql.adapter;
 import ddog.domain.payment.Reservation;
 import ddog.domain.payment.enums.ReservationStatus;
 import ddog.domain.payment.enums.ServiceType;
+import ddog.domain.payment.port.ReservationPersist;
 import ddog.persistence.mysql.jpa.entity.ReservationJpaEntity;
 import ddog.persistence.mysql.jpa.repository.ReservationJpaRepository;
-import ddog.domain.payment.port.ReservationPersist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +38,14 @@ public class ReservationRepository implements ReservationPersist {
         return reservationJpaRepository.findByCustomerIdAndServiceTypeAndReservationStatus(
                         accountId, serviceType, ReservationStatus.DEPOSIT_PAID, pageable)
                 .map(ReservationJpaEntity::toModel);
+    }
+
+    @Override
+    public List<Reservation> findByTypeAndStatusAndCustomerId(ServiceType type, ReservationStatus status, Long customerId) {
+        return reservationJpaRepository.findReservationJpaEntitiesByServiceTypeAndReservationStatusAndCustomerId(type, status, customerId)
+                .stream()
+                .map(ReservationJpaEntity::toModel)
+                .toList();
     }
 
     @Override

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/OrderJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/OrderJpaEntity.java
@@ -22,6 +22,8 @@ public class OrderJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long orderId;
 
+    private Long petId;
+
     @Enumerated(EnumType.STRING)
     private ServiceType serviceType;
 
@@ -47,6 +49,7 @@ public class OrderJpaEntity {
     public Order toModel() {
         return Order.builder()
                 .orderId(this.orderId)
+                .petId(this.petId)
                 .serviceType(this.serviceType)
                 .price(this.price)
                 .estimateId(this.estimateId)
@@ -71,6 +74,7 @@ public class OrderJpaEntity {
 
         return OrderJpaEntity.builder()
                 .orderId(order.getOrderId())
+                .petId(order.getPetId())
                 .serviceType(order.getServiceType())
                 .price(order.getPrice())
                 .estimateId(order.getEstimateId())

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ReservationJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ReservationJpaEntity.java
@@ -43,7 +43,6 @@ public class ReservationJpaEntity {
     private String visitorName;
     private String visitorPhoneNumber;
     private Long paymentId;
-    private Long petId;
 
     public static ReservationJpaEntity from(Reservation reservation) {
         return ReservationJpaEntity.builder()
@@ -64,7 +63,6 @@ public class ReservationJpaEntity {
                 .visitorName(reservation.getVisitorName())
                 .visitorPhoneNumber(reservation.getVisitorPhoneNumber())
                 .paymentId(reservation.getPaymentId())
-                .petId(reservation.getPetId())
                 .build();
     }
 
@@ -87,7 +85,6 @@ public class ReservationJpaEntity {
                 .visitorName(visitorName)
                 .visitorPhoneNumber(visitorPhoneNumber)
                 .paymentId(paymentId)
-                .petId(petId)
                 .build();
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ReservationJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ReservationJpaEntity.java
@@ -23,6 +23,7 @@ public class ReservationJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long reservationId;
     private Long estimateId;
+    private Long petId;
 
     @Enumerated(EnumType.STRING)
     private ServiceType serviceType;
@@ -48,6 +49,7 @@ public class ReservationJpaEntity {
         return ReservationJpaEntity.builder()
                 .reservationId(reservation.getReservationId())
                 .estimateId(reservation.getEstimateId())
+                .petId(reservation.getPetId())
                 .serviceType(reservation.getServiceType())
                 .reservationStatus(reservation.getReservationStatus())
                 .recipientId(reservation.getRecipientId())
@@ -70,6 +72,7 @@ public class ReservationJpaEntity {
         return Reservation.builder()
                 .reservationId(reservationId)
                 .estimateId(estimateId)
+                .petId(petId)
                 .serviceType(serviceType)
                 .reservationStatus(reservationStatus)
                 .recipientId(recipientId)

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/ReservationJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/ReservationJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -18,6 +19,8 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationJpaEn
 
     Page<ReservationJpaEntity> findByCustomerIdAndServiceTypeAndReservationStatus(
             Long customerId, ServiceType serviceType, ReservationStatus reservationStatus, Pageable pageable);
+
+    List<ReservationJpaEntity> findReservationJpaEntitiesByServiceTypeAndReservationStatusAndCustomerId(ServiceType serviceType, ReservationStatus reservationStatus, Long customerId);
 
     @Query("SELECT r FROM Reservations r WHERE DATE(r.schedule) = :today AND r.serviceType = :serviceType AND r.recipientId = :recipientId")
     List<ReservationJpaEntity> findTodayReservationByVetId(LocalDate today, ServiceType serviceType, Long recipientId);

--- a/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/AccountService.java
@@ -9,6 +9,8 @@ import ddog.domain.pet.Pet;
 import ddog.domain.pet.port.PetPersist;
 import ddog.domain.user.User;
 import ddog.domain.user.port.UserPersist;
+import ddog.user.application.exception.account.PetException;
+import ddog.user.application.exception.account.PetExceptionType;
 import ddog.user.application.exception.account.UserException;
 import ddog.user.application.exception.account.UserExceptionType;
 import ddog.user.application.mapper.PetMapper;
@@ -219,6 +221,9 @@ public class AccountService {
 
     @Transactional
     public AccountResp deletePet(Long petId) {
+        petPersist.findByPetId(petId)
+                .orElseThrow(() -> new PetException(PetExceptionType.PET_NOT_FOUND));
+
         petPersist.deletePetById(petId);
 
         return AccountResp.builder()

--- a/daengle-user-api/src/main/java/ddog/user/application/ReservationService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/ReservationService.java
@@ -1,5 +1,10 @@
 package ddog.user.application;
 
+import ddog.domain.estimate.CareEstimate;
+import ddog.domain.estimate.GroomingEstimate;
+import ddog.domain.estimate.port.CareEstimatePersist;
+import ddog.domain.estimate.port.GroomingEstimatePersist;
+import ddog.domain.groomer.Groomer;
 import ddog.domain.groomer.port.GroomerPersist;
 import ddog.domain.payment.Reservation;
 import ddog.domain.payment.enums.ReservationStatus;
@@ -7,12 +12,13 @@ import ddog.domain.payment.enums.ServiceType;
 import ddog.domain.payment.port.ReservationPersist;
 import ddog.domain.pet.Pet;
 import ddog.domain.pet.port.PetPersist;
-import ddog.domain.user.port.UserPersist;
-import ddog.user.application.exception.account.PetException;
-import ddog.user.application.exception.account.PetExceptionType;
-import ddog.user.application.exception.estimate.ReservationException;
-import ddog.user.application.exception.estimate.ReservationExceptionType;
-import ddog.user.presentation.reservation.dto.EstimateInfo;
+import ddog.domain.vet.Vet;
+import ddog.domain.vet.port.VetPersist;
+import ddog.user.application.exception.account.*;
+import ddog.user.application.exception.estimate.*;
+import ddog.user.application.mapper.ReservationMapper;
+import ddog.user.presentation.reservation.dto.EstimateDetail;
+import ddog.user.presentation.reservation.dto.ReservationInfo;
 import ddog.user.presentation.reservation.dto.ReservationSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,9 +32,11 @@ import java.util.List;
 public class ReservationService {
 
     private final ReservationPersist reservationPersist;
-    private final UserPersist userPersist;
-    private final GroomerPersist groomerPersist;
     private final PetPersist petPersist;
+    private final VetPersist vetPersist;
+    private final GroomerPersist groomerPersist;
+    private final GroomingEstimatePersist groomingEstimatePersist;
+    private final CareEstimatePersist careEstimatePersist;
 
     @Transactional(readOnly = true)
     public ReservationSummary getReservationSummary(Long reservationId) {
@@ -43,48 +51,58 @@ public class ReservationService {
                 .build();
     }
 
-    public EstimateInfo.Grooming findGroomingEstimates(Long accountId) {
+    public ReservationInfo.Grooming findGroomingEstimates(Long accountId) {
         List<Reservation> estimates = reservationPersist.findByTypeAndStatusAndCustomerId(ServiceType.GROOMING, ReservationStatus.DEPOSIT_PAID, accountId);
 
-        List<EstimateInfo.Grooming.Content> contents = new ArrayList<>();
+        List<ReservationInfo.Grooming.Content> contents = new ArrayList<>();
         for (Reservation estimate : estimates) {
             Pet pet = petPersist.findByPetId(estimate.getPetId())
                     .orElseThrow(() -> new PetException(PetExceptionType.PET_NOT_FOUND));
 
-            contents.add(EstimateInfo.Grooming.Content.builder()
-                    .estimateId(estimate.getEstimateId())
-                    .groomerName(estimate.getRecipientName())
-                    .petName(pet.getName())
-                    .petImageUrl(pet.getImageUrl())
-                    .shopName(estimate.getShopName())
-                    .reservedDate(estimate.getSchedule())
-                    .build());
+            contents.add(ReservationMapper.mapToGroomingContent(estimate, pet));
         }
 
-        return EstimateInfo.Grooming.builder()
+        return ReservationInfo.Grooming.builder()
                 .contents(contents)
                 .build();
     }
 
-    public EstimateInfo.Care findCareEstimates(Long accountId) {
+    public ReservationInfo.Care findCareEstimates(Long accountId) {
         List<Reservation> estimates = reservationPersist.findByTypeAndStatusAndCustomerId(ServiceType.CARE, ReservationStatus.DEPOSIT_PAID, accountId);
 
-        List<EstimateInfo.Care.Content> contents = new ArrayList<>();
+        List<ReservationInfo.Care.Content> contents = new ArrayList<>();
         for (Reservation estimate : estimates) {
             Pet pet = petPersist.findByPetId(estimate.getPetId())
                     .orElseThrow(() -> new PetException(PetExceptionType.PET_NOT_FOUND));
 
-            contents.add(EstimateInfo.Care.Content.builder()
-                    .estimateId(estimate.getEstimateId())
-                    .vetName(estimate.getRecipientName())
-                    .petName(pet.getName())
-                    .petImageUrl(pet.getImageUrl())
-                    .reservedDate(estimate.getSchedule())
-                    .build());
+            contents.add(ReservationMapper.mapToCareContent(estimate, pet));
         }
 
-        return EstimateInfo.Care.builder()
+        return ReservationInfo.Care.builder()
                 .contents(contents)
                 .build();
+    }
+
+    public EstimateDetail.Grooming getGroomingEstimateDetail(Long estimateId) {
+        GroomingEstimate estimate = groomingEstimatePersist.findByEstimateId(estimateId)
+                .orElseThrow(() -> new GroomingEstimateException(GroomingEstimateExceptionType.GROOMING_ESTIMATE_NOT_FOUND));
+
+        Groomer groomer = groomerPersist.findByAccountId(estimate.getGroomerId())
+                .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));
+
+        Pet pet = petPersist.findByPetId(estimate.getPetId())
+                .orElseThrow(() -> new PetException(PetExceptionType.PET_NOT_FOUND));
+
+        return ReservationMapper.mapToGroomingEstimateDetail(estimateId, groomer, estimate, pet);
+    }
+
+    public EstimateDetail.Care getCareEstimateDetail(Long estimateId) {
+        CareEstimate estimate = careEstimatePersist.findByEstimateId(estimateId)
+                .orElseThrow(() -> new CareEstimateException(CareEstimateExceptionType.CARE_ESTIMATE_NOT_FOUND));
+
+        Vet vet = vetPersist.findByAccountId(estimate.getVetId())
+                .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));
+
+        return ReservationMapper.mapToCareEstimateDetail(estimateId, vet, estimate);
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/ReservationService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/ReservationService.java
@@ -87,7 +87,7 @@ public class ReservationService {
         GroomingEstimate estimate = groomingEstimatePersist.findByEstimateId(estimateId)
                 .orElseThrow(() -> new GroomingEstimateException(GroomingEstimateExceptionType.GROOMING_ESTIMATE_NOT_FOUND));
 
-        Groomer groomer = groomerPersist.findByAccountId(estimate.getGroomerId())
+        Groomer groomer = groomerPersist.findByGroomerId(estimate.getGroomerId())
                 .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));
 
         Pet pet = petPersist.findByPetId(estimate.getPetId())
@@ -100,7 +100,7 @@ public class ReservationService {
         CareEstimate estimate = careEstimatePersist.findByEstimateId(estimateId)
                 .orElseThrow(() -> new CareEstimateException(CareEstimateExceptionType.CARE_ESTIMATE_NOT_FOUND));
 
-        Vet vet = vetPersist.findByAccountId(estimate.getVetId())
+        Vet vet = vetPersist.findByVetId(estimate.getVetId())
                 .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));
 
         return ReservationMapper.mapToCareEstimateDetail(estimateId, vet, estimate);

--- a/daengle-user-api/src/main/java/ddog/user/application/ReservationService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/ReservationService.java
@@ -1,19 +1,34 @@
 package ddog.user.application;
 
+import ddog.domain.groomer.port.GroomerPersist;
 import ddog.domain.payment.Reservation;
+import ddog.domain.payment.enums.ReservationStatus;
+import ddog.domain.payment.enums.ServiceType;
 import ddog.domain.payment.port.ReservationPersist;
+import ddog.domain.pet.Pet;
+import ddog.domain.pet.port.PetPersist;
+import ddog.domain.user.port.UserPersist;
+import ddog.user.application.exception.account.PetException;
+import ddog.user.application.exception.account.PetExceptionType;
 import ddog.user.application.exception.estimate.ReservationException;
 import ddog.user.application.exception.estimate.ReservationExceptionType;
+import ddog.user.presentation.reservation.dto.EstimateInfo;
 import ddog.user.presentation.reservation.dto.ReservationSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
 
     private final ReservationPersist reservationPersist;
+    private final UserPersist userPersist;
+    private final GroomerPersist groomerPersist;
+    private final PetPersist petPersist;
 
     @Transactional(readOnly = true)
     public ReservationSummary getReservationSummary(Long reservationId) {
@@ -25,6 +40,51 @@ public class ReservationService {
                 .recipientName(reservation.getRecipientName())
                 .shopName(reservation.getShopName())
                 .schedule(reservation.getSchedule())
+                .build();
+    }
+
+    public EstimateInfo.Grooming findGroomingEstimates(Long accountId) {
+        List<Reservation> estimates = reservationPersist.findByTypeAndStatusAndCustomerId(ServiceType.GROOMING, ReservationStatus.DEPOSIT_PAID, accountId);
+
+        List<EstimateInfo.Grooming.Content> contents = new ArrayList<>();
+        for (Reservation estimate : estimates) {
+            Pet pet = petPersist.findByPetId(estimate.getPetId())
+                    .orElseThrow(() -> new PetException(PetExceptionType.PET_NOT_FOUND));
+
+            contents.add(EstimateInfo.Grooming.Content.builder()
+                    .estimateId(estimate.getEstimateId())
+                    .groomerName(estimate.getRecipientName())
+                    .petName(pet.getName())
+                    .petImageUrl(pet.getImageUrl())
+                    .shopName(estimate.getShopName())
+                    .reservedDate(estimate.getSchedule())
+                    .build());
+        }
+
+        return EstimateInfo.Grooming.builder()
+                .contents(contents)
+                .build();
+    }
+
+    public EstimateInfo.Care findCareEstimates(Long accountId) {
+        List<Reservation> estimates = reservationPersist.findByTypeAndStatusAndCustomerId(ServiceType.CARE, ReservationStatus.DEPOSIT_PAID, accountId);
+
+        List<EstimateInfo.Care.Content> contents = new ArrayList<>();
+        for (Reservation estimate : estimates) {
+            Pet pet = petPersist.findByPetId(estimate.getPetId())
+                    .orElseThrow(() -> new PetException(PetExceptionType.PET_NOT_FOUND));
+
+            contents.add(EstimateInfo.Care.Content.builder()
+                    .estimateId(estimate.getEstimateId())
+                    .vetName(estimate.getRecipientName())
+                    .petName(pet.getName())
+                    .petImageUrl(pet.getImageUrl())
+                    .reservedDate(estimate.getSchedule())
+                    .build());
+        }
+
+        return EstimateInfo.Care.builder()
+                .contents(contents)
                 .build();
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/ReservationMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/ReservationMapper.java
@@ -1,0 +1,69 @@
+package ddog.user.application.mapper;
+
+import ddog.domain.estimate.CareEstimate;
+import ddog.domain.estimate.GroomingEstimate;
+import ddog.domain.groomer.Groomer;
+import ddog.domain.payment.Reservation;
+import ddog.domain.pet.Pet;
+import ddog.domain.vet.Vet;
+import ddog.user.presentation.reservation.dto.EstimateDetail;
+import ddog.user.presentation.reservation.dto.ReservationInfo;
+
+public class ReservationMapper {
+
+    public static ReservationInfo.Grooming.Content mapToGroomingContent(Reservation estimate, Pet pet) {
+        return ReservationInfo.Grooming.Content.builder()
+                .estimateId(estimate.getEstimateId())
+                .groomerName(estimate.getRecipientName())
+                .petName(pet.getName())
+                .petImageUrl(pet.getImageUrl())
+                .shopName(estimate.getShopName())
+                .reservedDate(estimate.getSchedule())
+                .build();
+    }
+
+    public static ReservationInfo.Care.Content mapToCareContent(Reservation estimate, Pet pet) {
+        return ReservationInfo.Care.Content.builder()
+                .estimateId(estimate.getEstimateId())
+                .vetName(estimate.getRecipientName())
+                .petName(pet.getName())
+                .petImageUrl(pet.getImageUrl())
+                .reservedDate(estimate.getSchedule())
+                .build();
+    }
+
+    public static EstimateDetail.Grooming mapToGroomingEstimateDetail(Long estimateId, Groomer groomer, GroomingEstimate estimate, Pet pet) {
+        return EstimateDetail.Grooming.builder()
+                .groomingEstimateId(estimateId)
+                .groomerId(groomer.getAccountId())
+                .imageUrl(groomer.getImageUrl())
+                .name(groomer.getName())
+                .shopName(groomer.getShopName())
+                .daengleMeter(groomer.getDaengleMeter())
+                .keywords(groomer.getKeywords())
+                .introduction(groomer.getIntroduction())
+                .address(groomer.getAddress())
+                .reservedDate(estimate.getReservedDate())
+                .weight(pet.getWeight())
+                .desiredStyle(estimate.getDesiredStyle())
+                .overallOpinion(estimate.getOverallOpinion())
+                .build();
+    }
+
+    public static EstimateDetail.Care mapToCareEstimateDetail(Long estimateId, Vet vet, CareEstimate estimate) {
+        return EstimateDetail.Care.builder()
+                .careEstimateId(estimateId)
+                .vetId(vet.getAccountId())
+                .imageUrl(vet.getImageUrl())
+                .name(vet.getName())
+                .daengleMeter(vet.getDaengleMeter())
+                .keywords(vet.getKeywords())
+                .introduction(vet.getIntroduction())
+                .address(vet.getAddress())
+                .reservedDate(estimate.getReservedDate())
+                .diagnosis(estimate.getDiagnosis())
+                .cause(estimate.getCause())
+                .treatment(estimate.getTreatment())
+                .build();
+    }
+}

--- a/daengle-user-api/src/main/java/ddog/user/presentation/reservation/ReservationController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/reservation/ReservationController.java
@@ -3,7 +3,8 @@ package ddog.user.presentation.reservation;
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
 import ddog.user.application.ReservationService;
-import ddog.user.presentation.reservation.dto.EstimateInfo;
+import ddog.user.presentation.reservation.dto.EstimateDetail;
+import ddog.user.presentation.reservation.dto.ReservationInfo;
 import ddog.user.presentation.reservation.dto.ReservationSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -23,12 +24,22 @@ public class ReservationController {
     }
 
     @GetMapping("/grooming/list")
-    public CommonResponseEntity<EstimateInfo.Grooming> findGroomingEstimates(PayloadDto payloadDto) {
+    public CommonResponseEntity<ReservationInfo.Grooming> findGroomingEstimates(PayloadDto payloadDto) {
         return success(reservationService.findGroomingEstimates(payloadDto.getAccountId()));
     }
 
     @GetMapping("/care/list")
-    public CommonResponseEntity<EstimateInfo.Care> findCareEstimates(PayloadDto payloadDto) {
+    public CommonResponseEntity<ReservationInfo.Care> findCareEstimates(PayloadDto payloadDto) {
         return success(reservationService.findCareEstimates(payloadDto.getAccountId()));
+    }
+
+    @GetMapping("/grooming/{estimateId}/detail")
+    public CommonResponseEntity<EstimateDetail.Grooming> getGroomingEstimateDetail(@PathVariable Long estimateId) {
+        return success(reservationService.getGroomingEstimateDetail(estimateId));
+    }
+
+    @GetMapping("/care/{estimateId}/detail")
+    public CommonResponseEntity<EstimateDetail.Care> getCareEstimateDetail(@PathVariable Long estimateId) {
+        return success(reservationService.getCareEstimateDetail(estimateId));
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/reservation/ReservationController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/reservation/ReservationController.java
@@ -1,13 +1,12 @@
 package ddog.user.presentation.reservation;
 
+import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
 import ddog.user.application.ReservationService;
+import ddog.user.presentation.reservation.dto.EstimateInfo;
 import ddog.user.presentation.reservation.dto.ReservationSummary;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static ddog.auth.exception.common.CommonResponseEntity.success;
 
@@ -21,5 +20,15 @@ public class ReservationController {
     @GetMapping("/{reservationId}/review")
     public CommonResponseEntity<ReservationSummary> getReservationSummary(@PathVariable Long reservationId) {
         return success(reservationService.getReservationSummary(reservationId));
+    }
+
+    @GetMapping("/grooming/list")
+    public CommonResponseEntity<EstimateInfo.Grooming> findGroomingEstimates(PayloadDto payloadDto) {
+        return success(reservationService.findGroomingEstimates(payloadDto.getAccountId()));
+    }
+
+    @GetMapping("/care/list")
+    public CommonResponseEntity<EstimateInfo.Care> findCareEstimates(PayloadDto payloadDto) {
+        return success(reservationService.findCareEstimates(payloadDto.getAccountId()));
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/reservation/dto/EstimateDetail.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/reservation/dto/EstimateDetail.java
@@ -1,0 +1,57 @@
+package ddog.user.presentation.reservation.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import ddog.domain.estimate.Proposal;
+import ddog.domain.groomer.enums.GroomingKeyword;
+import ddog.domain.pet.Weight;
+import ddog.domain.vet.enums.CareKeyword;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class EstimateDetail {
+
+    @Getter
+    @Builder
+    public static class Grooming {
+        private Long groomingEstimateId;
+        private Long groomerId;
+        private String imageUrl;
+        private String name;
+        private String shopName;
+        private int daengleMeter;
+        private List<GroomingKeyword> keywords;
+        private String introduction;
+        private String address;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime reservedDate;
+        private Weight weight;
+        private String desiredStyle;
+        private String overallOpinion;
+    }
+
+    @Getter
+    @Builder
+    public static class Care {
+        private Long careEstimateId;
+        private Long vetId;
+        private String imageUrl;
+        private String name;
+        private int daengleMeter;
+        private List<CareKeyword> keywords;
+        private String introduction;
+        private String address;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime reservedDate;
+        private String diagnosis;
+        private String cause;
+        private String treatment;
+    }
+
+}

--- a/daengle-user-api/src/main/java/ddog/user/presentation/reservation/dto/EstimateInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/reservation/dto/EstimateInfo.java
@@ -1,0 +1,52 @@
+package ddog.user.presentation.reservation.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class EstimateInfo {
+
+    @Getter
+    @Builder
+    public static class Grooming {
+
+        private List<Content> contents;
+
+        @Getter
+        @Builder
+        public static class Content {
+            private Long estimateId;
+            private String groomerName;
+            private String petName;
+            private String petImageUrl;
+            private String shopName;
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+            private LocalDateTime reservedDate;
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Care {
+
+        private List<Content> contents;
+
+        @Getter
+        @Builder
+        public static class Content {
+            private Long estimateId;
+            private String vetName;
+            private String petName;
+            private String petImageUrl;
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+            private LocalDateTime reservedDate;
+        }
+    }
+}

--- a/daengle-user-api/src/main/java/ddog/user/presentation/reservation/dto/ReservationInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/reservation/dto/ReservationInfo.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class EstimateInfo {
+public class ReservationInfo {
 
     @Getter
     @Builder


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 예약중인 미용 견적서들 페이징 조회 API 구현
    - 예약중인 진료 견적서들 페이징 조회 API 구현
    - 예약중인 미용 견적서 상세 조회 API 구현
    - 예약중인 진료 견적서 상세 조회 API 구현

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : Order, Reservation 테이블에 petId 데이터 추가

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
