### PR TITLE
[feat/daengle-76] 프로필 조회 및 수정 관련 API 기능 추가

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
@@ -26,7 +26,7 @@ public class Groomer {
     private String shopName;
     private String introduction;
     private List<String> businessLicenses;
-    private List<String> licenses;
+    private List<License> licenses;
     private List<GroomingKeyword> keywords;
 
     public static void validateShopName(String shopName) {

--- a/daengle-domain/src/main/java/ddog/domain/groomer/License.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/License.java
@@ -1,0 +1,30 @@
+package ddog.domain.groomer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class License {
+
+    private Long licenseId;
+    private Long accountId;
+    private String imageUrl;
+    private String name;
+    private LocalDateTime acquisitionDate;
+
+    public static License createWithImageUrl(Long accountId, String imageUrl) {
+        return License.builder()
+                .accountId(accountId)
+                .imageUrl(imageUrl)
+                .name("")
+                .acquisitionDate(null)
+                .build();
+    }
+}

--- a/daengle-domain/src/main/java/ddog/domain/groomer/License.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/License.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -17,7 +17,7 @@ public class License {
     private Long accountId;
     private String imageUrl;
     private String name;
-    private LocalDateTime acquisitionDate;
+    private LocalDate acquisitionDate;
 
     public static License createWithImageUrl(Long accountId, String imageUrl) {
         return License.builder()

--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/LicensePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/LicensePersist.java
@@ -1,0 +1,8 @@
+package ddog.domain.groomer.port;
+
+import ddog.domain.groomer.License;
+
+public interface LicensePersist {
+
+    License save(License license);
+}

--- a/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
@@ -23,6 +23,7 @@ public class Vet {
     private int daengleMeter;
     private String name;
     private String imageUrl;
+    private List<String> imageUrlList;
     private String address;
     private String detailAddress;
     private String phoneNumber;
@@ -32,6 +33,10 @@ public class Vet {
     private List<Day> closedDays;
     private List<String> licenses;
     private List<CareKeyword> keywords;
+
+    public void updateWithImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 
     public static void validateName(String name) {
         if (name == null || name.length() < 2 || name.length() > 10 || !name.matches("^[가-힣\\s]+$")) {

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -4,6 +4,8 @@ import ddog.auth.config.jwt.JwtTokenProvider;
 import ddog.domain.account.Account;
 import ddog.domain.account.Role;
 import ddog.domain.groomer.Groomer;
+import ddog.domain.groomer.License;
+import ddog.domain.groomer.port.LicensePersist;
 import ddog.groomer.application.exception.account.GroomerException;
 import ddog.groomer.application.exception.account.GroomerExceptionType;
 import ddog.groomer.application.mapper.GroomerMapper;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -31,6 +34,7 @@ public class AccountService {
 
     private final AccountPersist accountPersist;
     private final GroomerPersist groomerPersist;
+    private final LicensePersist licensePersist;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -41,7 +45,15 @@ public class AccountService {
         Account newAccount = Account.create(request.getEmail(), Role.GROOMER);
         Account savedAccount = accountPersist.save(newAccount);
 
-        Groomer newGroomer = GroomerMapper.create(savedAccount.getAccountId(), request);
+        List<License> licenses = new ArrayList<>();
+        for (String imageUrl : request.getLicenses()) {
+            License newLicense = License.createWithImageUrl(savedAccount.getAccountId(), imageUrl);
+            License savedLicense = licensePersist.save(newLicense);
+
+            licenses.add(savedLicense);
+        }
+
+        Groomer newGroomer = GroomerMapper.create(savedAccount.getAccountId(), request, licenses);
         groomerPersist.save(newGroomer);
 
         Authentication authentication = getAuthentication(savedAccount.getAccountId(), request.getEmail());

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -89,7 +89,16 @@ public class AccountService {
         Groomer groomer = groomerPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));
 
-        return GroomerMapper.toModifyPage(groomer);
+        List<License> licenses = groomer.getLicenses();
+        List<ProfileInfo.UpdatePage.LicenseDetail> details = new ArrayList<>();
+        for (License license : licenses) {
+            details.add(ProfileInfo.UpdatePage.LicenseDetail.builder()
+                    .name(license.getName())
+                    .acquisitionDate(license.getAcquisitionDate())
+                    .build());
+        }
+
+        return GroomerMapper.toModifyPage(groomer, details);
     }
 
     @Transactional

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -98,7 +98,7 @@ public class AccountService {
                     .build());
         }
 
-        return GroomerMapper.toModifyPage(groomer, details);
+        return GroomerMapper.mapToUpdatePage(groomer, details);
     }
 
     @Transactional
@@ -108,7 +108,7 @@ public class AccountService {
         Groomer groomer = groomerPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));
 
-        Groomer updatedGroomer = GroomerMapper.withUpdate(groomer, request);
+        Groomer updatedGroomer = GroomerMapper.updateWithUpdateInfoReq(groomer, request);
         groomerPersist.save(updatedGroomer);
 
         return AccountResp.builder()

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
@@ -26,7 +26,7 @@ public class GroomerMapper {
                 .build();
     }
 
-    public static ProfileInfo.UpdatePage toModifyPage(Groomer groomer, List<ProfileInfo.UpdatePage.LicenseDetail> details) {
+    public static ProfileInfo.UpdatePage mapToUpdatePage(Groomer groomer, List<ProfileInfo.UpdatePage.LicenseDetail> details) {
         return ProfileInfo.UpdatePage.builder()
                 .image(groomer.getImageUrl())
                 .name(groomer.getName())
@@ -37,7 +37,7 @@ public class GroomerMapper {
                 .build();
     }
 
-    public static Groomer withUpdate(Groomer groomer, UpdateInfoReq request) {
+    public static Groomer updateWithUpdateInfoReq(Groomer groomer, UpdateInfoReq request) {
         return Groomer.builder()
                 .groomerId(groomer.getGroomerId())
                 .accountId(groomer.getAccountId())

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
@@ -33,7 +33,6 @@ public class GroomerMapper {
                 .phoneNumber(groomer.getPhoneNumber())
                 .email(groomer.getEmail())
                 .introduction(groomer.getIntroduction())
-                .businessLicences(groomer.getBusinessLicenses())
                 .licenses(details)
                 .build();
     }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
@@ -26,7 +26,7 @@ public class GroomerMapper {
                 .build();
     }
 
-    public static ProfileInfo.UpdatePage toModifyPage(Groomer groomer) {
+    public static ProfileInfo.UpdatePage toModifyPage(Groomer groomer, List<ProfileInfo.UpdatePage.LicenseDetail> details) {
         return ProfileInfo.UpdatePage.builder()
                 .image(groomer.getImageUrl())
                 .name(groomer.getName())
@@ -34,7 +34,7 @@ public class GroomerMapper {
                 .email(groomer.getEmail())
                 .introduction(groomer.getIntroduction())
                 .businessLicences(groomer.getBusinessLicenses())
-                .licenses(groomer.getLicenses())
+                .licenses(details)
                 .build();
     }
 

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
@@ -1,16 +1,20 @@
 package ddog.groomer.application.mapper;
 
 import ddog.domain.groomer.Groomer;
+import ddog.domain.groomer.License;
 import ddog.groomer.presentation.account.dto.UpdateInfoReq;
 import ddog.groomer.presentation.account.dto.ProfileInfo;
 import ddog.groomer.presentation.account.dto.SignUpReq;
 
+import java.util.List;
+
 public class GroomerMapper {
 
-    public static Groomer create(Long accountId, SignUpReq request) {
+    public static Groomer create(Long accountId, SignUpReq request, List<License> licenses) {
         return Groomer.builder()
                 .accountId(accountId)
                 .daengleMeter(0)
+                .imageUrl("")
                 .name(request.getName())
                 .phoneNumber(request.getPhoneNumber())
                 .email(request.getEmail())
@@ -18,7 +22,7 @@ public class GroomerMapper {
                 .detailAddress(request.getDetailAddress())
                 .shopName(request.getShopName())
                 .businessLicenses(request.getBusinessLicenses())
-                .licenses(request.getLicenses())
+                .licenses(licenses)
                 .build();
     }
 

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/dto/ProfileInfo.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/dto/ProfileInfo.java
@@ -1,9 +1,10 @@
 package ddog.groomer.presentation.account.dto;
 
-import ddog.domain.groomer.License;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -19,6 +20,15 @@ public class ProfileInfo {
         private String email;
         private String introduction;
         private List<String> businessLicences;
-        private List<License> licenses;
+        private List<LicenseDetail> licenses;
+
+        @Getter
+        @Builder
+        public static class LicenseDetail {
+            private String name;
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+            private LocalDateTime acquisitionDate;
+        }
     }
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/dto/ProfileInfo.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/dto/ProfileInfo.java
@@ -1,5 +1,6 @@
 package ddog.groomer.presentation.account.dto;
 
+import ddog.domain.groomer.License;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,6 +19,6 @@ public class ProfileInfo {
         private String email;
         private String introduction;
         private List<String> businessLicences;
-        private List<String> licenses;
+        private List<License> licenses;
     }
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/dto/ProfileInfo.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/dto/ProfileInfo.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -19,7 +19,6 @@ public class ProfileInfo {
         private String phoneNumber;
         private String email;
         private String introduction;
-        private List<String> businessLicences;
         private List<LicenseDetail> licenses;
 
         @Getter
@@ -27,8 +26,8 @@ public class ProfileInfo {
         public static class LicenseDetail {
             private String name;
 
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-            private LocalDateTime acquisitionDate;
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+            private LocalDate acquisitionDate;
         }
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/LicenseRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/LicenseRepository.java
@@ -1,0 +1,21 @@
+package ddog.persistence.mysql.adapter;
+
+import ddog.domain.groomer.License;
+import ddog.domain.groomer.port.LicensePersist;
+import ddog.persistence.mysql.jpa.entity.LicenseJpaEntity;
+import ddog.persistence.mysql.jpa.repository.LicenseJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LicenseRepository implements LicensePersist {
+
+    private final LicenseJpaRepository licenseJpaRepository;
+
+    @Override
+    public License save(License license) {
+        return licenseJpaRepository.save(LicenseJpaEntity.from(license))
+                .toModel();
+    }
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomerJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomerJpaEntity.java
@@ -1,6 +1,7 @@
 package ddog.persistence.mysql.jpa.entity;
 
 import ddog.domain.groomer.Groomer;
+import ddog.domain.groomer.License;
 import ddog.domain.groomer.enums.GroomingKeyword;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -36,10 +37,9 @@ public class GroomerJpaEntity {
     @Column(name = "business_license_url")
     private List<String> businessLicenses;
 
-    @ElementCollection // 자격증 URL 리스트
-    @CollectionTable(name = "groomer_licenses", joinColumns = @JoinColumn(name = "groomer_id"))
-    @Column(name = "license_url")
-    private List<String> licenses;
+    @OneToMany
+    @JoinColumn(name = "account_id", referencedColumnName = "accountId")
+    private List<LicenseJpaEntity> licenses;
 
     @ElementCollection // 해시태그 리스트
     @CollectionTable(name = "grooming_keywords", joinColumns = @JoinColumn(name = "groomer_id"))
@@ -60,7 +60,9 @@ public class GroomerJpaEntity {
                 .shopName(groomer.getShopName())
                 .introduction(groomer.getIntroduction())
                 .businessLicenses(groomer.getBusinessLicenses())
-                .licenses(groomer.getLicenses())
+                .licenses(groomer.getLicenses().stream()
+                        .map(LicenseJpaEntity::from)
+                        .toList())
                 .keywords(groomer.getKeywords())
                 .build();
     }
@@ -79,7 +81,9 @@ public class GroomerJpaEntity {
                 .shopName(shopName)
                 .introduction(introduction)
                 .businessLicenses(businessLicenses)
-                .licenses(licenses)
+                .licenses(licenses.stream()
+                        .map(LicenseJpaEntity::toModel)
+                        .toList())
                 .keywords(keywords)
                 .build();
     }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/LicenseJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/LicenseJpaEntity.java
@@ -1,0 +1,48 @@
+package ddog.persistence.mysql.jpa.entity;
+
+import ddog.domain.groomer.License;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "Licenses")
+public class LicenseJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long licenseId;
+
+    @Column(name = "account_id")
+    private Long accountId;
+    private String imageUrl;
+    private String name;
+    private LocalDateTime acquisitionDate;
+
+    public static LicenseJpaEntity from(License license) {
+        return LicenseJpaEntity.builder()
+                .licenseId(license.getLicenseId())
+                .accountId(license.getAccountId())
+                .imageUrl(license.getImageUrl())
+                .name(license.getName())
+                .acquisitionDate(license.getAcquisitionDate())
+                .build();
+    }
+
+    public License toModel() {
+        return License.builder()
+                .licenseId(licenseId)
+                .accountId(accountId)
+                .imageUrl(imageUrl)
+                .name(name)
+                .acquisitionDate(acquisitionDate)
+                .build();
+    }
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/LicenseJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/LicenseJpaEntity.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -24,7 +25,7 @@ public class LicenseJpaEntity {
     private Long accountId;
     private String imageUrl;
     private String name;
-    private LocalDateTime acquisitionDate;
+    private LocalDate acquisitionDate;
 
     public static LicenseJpaEntity from(License license) {
         return LicenseJpaEntity.builder()

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/VetJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/VetJpaEntity.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -27,6 +28,12 @@ public class VetJpaEntity {
     private int daengleMeter;
     private String name;
     private String imageUrl;
+
+    @ElementCollection // 휴무일 리스트
+    @CollectionTable(name = "vet_image_urls", joinColumns = @JoinColumn(name = "vet_id"))
+    @Column(name = "image_url")
+    private List<String> imageUrlList = new ArrayList<>();
+
     private String address;
     private String detailAddress;
     private String phoneNumber;
@@ -57,6 +64,7 @@ public class VetJpaEntity {
                 .daengleMeter(vet.getDaengleMeter())
                 .name(vet.getName())
                 .imageUrl(vet.getImageUrl())
+                .imageUrlList(vet.getImageUrlList())
                 .address(vet.getAddress())
                 .detailAddress(vet.getDetailAddress())
                 .phoneNumber(vet.getPhoneNumber())
@@ -77,6 +85,7 @@ public class VetJpaEntity {
                 .daengleMeter(daengleMeter)
                 .name(name)
                 .imageUrl(imageUrl)
+                .imageUrlList(imageUrlList)
                 .address(address)
                 .detailAddress(detailAddress)
                 .phoneNumber(phoneNumber)

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/LicenseJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/LicenseJpaRepository.java
@@ -1,0 +1,10 @@
+package ddog.persistence.mysql.jpa.repository;
+
+import ddog.persistence.mysql.jpa.entity.LicenseJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LicenseJpaRepository extends JpaRepository<LicenseJpaEntity, Long> {
+
+    LicenseJpaEntity save(LicenseJpaEntity license);
+
+}

--- a/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetMapper.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetMapper.java
@@ -1,7 +1,7 @@
 package ddog.vet.application.mapper;
 
 import ddog.domain.vet.Vet;
-import ddog.vet.presentation.account.dto.ModifyInfoReq;
+import ddog.vet.presentation.account.dto.UpdateInfo;
 import ddog.vet.presentation.account.dto.ProfileInfo;
 import ddog.vet.presentation.account.dto.SignUpReq;
 
@@ -14,6 +14,7 @@ public class VetMapper {
                 .accountId(accountId)
                 .daengleMeter(0)
                 .name(request.getName())
+                .imageUrl("")
                 .address(request.getAddress())
                 .detailAddress(request.getDetailAddress())
                 .phoneNumber(request.getPhoneNumber())
@@ -24,8 +25,8 @@ public class VetMapper {
                 .build();
     }
 
-    public static ProfileInfo.ModifyPage toModifyPage(Vet vet) {
-        return ProfileInfo.ModifyPage.builder()
+    public static ProfileInfo.UpdatePage mapToUpdatePage(Vet vet) {
+        return ProfileInfo.UpdatePage.builder()
                 .image(vet.getImageUrl())
                 .name(vet.getName())
                 .startTime(vet.getStartTime())
@@ -38,14 +39,15 @@ public class VetMapper {
                 .build();
     }
 
-    public static Vet withUpdate(Vet vet, ModifyInfoReq request) {
+    public static Vet updateWithUpdateInfo(Vet vet, UpdateInfo request, String imageUrl) {
         return Vet.builder()
                 .vetId(vet.getVetId())
                 .accountId(vet.getAccountId())
                 .email(vet.getEmail())
                 .daengleMeter(vet.getDaengleMeter())
                 .name(vet.getName())
-                .imageUrl(request.getImage())
+                .imageUrl(imageUrl)
+                .imageUrlList(request.getImageUrls())
                 .address(vet.getAddress())
                 .detailAddress(vet.getDetailAddress())
                 .phoneNumber(request.getPhoneNumber())

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/account/AccountController.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/account/AccountController.java
@@ -24,12 +24,12 @@ public class AccountController {
     }
 
     @GetMapping("/modify-page")
-    public CommonResponseEntity<ProfileInfo.ModifyPage> getModifyInfo(PayloadDto payloadDto) {
+    public CommonResponseEntity<ProfileInfo.UpdatePage> getModifyInfo(PayloadDto payloadDto) {
         return success(accountService.getModifyPage(payloadDto.getAccountId()));
     }
 
     @PatchMapping("/info")
-    public CommonResponseEntity<AccountResp> modifyInfo(@RequestBody ModifyInfoReq request, PayloadDto payloadDto) {
+    public CommonResponseEntity<AccountResp> modifyInfo(@RequestBody UpdateInfo request, PayloadDto payloadDto) {
         return success(accountService.modifyInfo(request, payloadDto.getAccountId()));
     }
 }

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/account/dto/ProfileInfo.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/account/dto/ProfileInfo.java
@@ -13,7 +13,7 @@ public class ProfileInfo {
 
     @Getter
     @Builder
-    public static class ModifyPage {
+    public static class UpdatePage {
         private String image;
         private String name;
         private LocalTime startTime;

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/account/dto/UpdateInfo.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/account/dto/UpdateInfo.java
@@ -7,8 +7,8 @@ import java.time.LocalTime;
 import java.util.List;
 
 @Getter
-public class ModifyInfoReq {
-    private String image;
+public class UpdateInfo {
+    private List<String> imageUrls;
     private LocalTime startTime;
     private LocalTime endTime;
     private List<Day> closedDays;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 미용사 프로필 조회중 자격증 정보에 대한 데이터 필드 추가
    - 병원 프로필 이미지 리스트 중 첫 번째 사진을 프로필 이미지로 전환하도록 기능 추가
    - 이미지 리스트가 변할 때마다 프로필 이미지로 전환할 수 있도록 기능 추가

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 데이터베이스의 필드 값이 일부 수정 및 추가 되었습니다.
    - 미용사의 경우 기존 자격증 이미지URL만 받아왔던 것에서 자격증의 추가 정보가 필요하기에 새로운 자격증 테이블을 생성해줬고 1:N 관계로 매핑했습니다.
    - 병원의 경우 수정 페이지에서 대표 프로필 사진을 받지 않기 때문에 여러개 받은 사진들 중 첫 번째 사진으로 대표 프로필 사진으로 설정되도록 변경했습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : `Groomer` 에서 `List<License>` 추가, `Vet` 에서 `List<String> imageUrlList` 추가

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
