### PR TITLE
[feat/daengle-83] 미용사/병원 마이페이지 정보 요청 API 구현

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
@@ -34,10 +34,6 @@ public class Vet {
     private List<String> licenses;
     private List<CareKeyword> keywords;
 
-    public void updateWithImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
-    }
-
     public static void validateName(String name) {
         if (name == null || name.length() < 2 || name.length() > 10 || !name.matches("^[가-힣\\s]+$")) {
             throw new IllegalArgumentException("Invalid name: must be 2-10 characters and in Korean.");
@@ -80,6 +76,9 @@ public class Vet {
     public static void validateTimeRange(LocalTime startTime, LocalTime endTime) {
         if (startTime == null || endTime == null) {
             throw new IllegalArgumentException("Invalid time: startTime and endTime cannot be null.");
+        }
+        if (startTime == endTime) {
+            throw new IllegalArgumentException("Invalid time: startTime and endTime cannot be the same.");
         }
         if (endTime.isBefore(startTime)) {
             throw new IllegalArgumentException("Invalid time range: endTime cannot be before startTime.");

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -95,6 +95,13 @@ public class AccountService {
         return authentication;
     }
 
+    public ProfileInfo getGroomerInfo(Long accountId) {
+        Groomer groomer = groomerPersist.findByAccountId(accountId)
+                .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));
+
+        return GroomerMapper.mapToProfileInfo(groomer);
+    }
+
     @Transactional(readOnly = true)
     public ProfileInfo.UpdatePage getUpdatePage(Long accountId) {
         Groomer groomer = groomerPersist.findByAccountId(accountId)

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
@@ -28,7 +28,15 @@ public class GroomerMapper {
     }
 
     public static ProfileInfo mapToProfileInfo(Groomer groomer) {
-        return null;
+        return ProfileInfo.builder()
+                .imageUrl(groomer.getImageUrl())
+                .name(groomer.getName())
+                .keywords(groomer.getKeywords())
+                .shopId(groomer.getShopId())
+                .shopName(groomer.getShopName())
+                .introduction(groomer.getIntroduction())
+                .daengleMeter(groomer.getDaengleMeter())
+                .build();
     }
 
     public static ProfileInfo.UpdatePage mapToUpdatePage(Groomer groomer, List<ProfileInfo.UpdatePage.LicenseDetail> details) {

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
@@ -27,6 +27,10 @@ public class GroomerMapper {
                 .build();
     }
 
+    public static ProfileInfo mapToProfileInfo(Groomer groomer) {
+        return null;
+    }
+
     public static ProfileInfo.UpdatePage mapToUpdatePage(Groomer groomer, List<ProfileInfo.UpdatePage.LicenseDetail> details) {
         return ProfileInfo.UpdatePage.builder()
                 .image(groomer.getImageUrl())

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/AccountController.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/AccountController.java
@@ -24,6 +24,11 @@ public class AccountController {
         return success(accountService.signUp(request, response));
     }
 
+    @GetMapping("/info")
+    public CommonResponseEntity<ProfileInfo> getGroomerInfo(PayloadDto payloadDto) {
+        return success(accountService.getGroomerInfo(payloadDto.getAccountId()));
+    }
+
     @GetMapping("/modify-page")
     public CommonResponseEntity<ProfileInfo.UpdatePage> getUpdateInfo(PayloadDto payloadDto) {
         return success(accountService.getUpdatePage(payloadDto.getAccountId()));

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/dto/ProfileInfo.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/dto/ProfileInfo.java
@@ -1,6 +1,7 @@
 package ddog.groomer.presentation.account.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,15 @@ import java.util.List;
 @Getter
 @Builder
 public class ProfileInfo {
+
+    private String imageUrl;
+    private String name;
+    private List<GroomingKeyword> keywords;
+    private Long shopId;
+    private String shopName;
+    private String introduction;
+    private int daengleMeter;
+
 
     @Getter
     @Builder

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingEstimateMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/GroomingEstimateMapper.java
@@ -109,6 +109,7 @@ public class GroomingEstimateMapper {
                 .groomerId(groomer.getGroomerId())
                 .imageUrl(groomer.getImageUrl())
                 .name(groomer.getName())
+                .shopId(groomer.getShopId())
                 .shopName(groomer.getShopName())
                 .daengleMeter(groomer.getDaengleMeter())
                 .proposal(estimate.getProposal())

--- a/daengle-user-api/src/main/java/ddog/user/application/mapper/ReservationMapper.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/mapper/ReservationMapper.java
@@ -38,6 +38,7 @@ public class ReservationMapper {
                 .groomerId(groomer.getAccountId())
                 .imageUrl(groomer.getImageUrl())
                 .name(groomer.getName())
+                .shopId(groomer.getShopId())
                 .shopName(groomer.getShopName())
                 .daengleMeter(groomer.getDaengleMeter())
                 .keywords(groomer.getKeywords())

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/dto/GroomingEstimateDetail.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/dto/GroomingEstimateDetail.java
@@ -16,6 +16,7 @@ public class GroomingEstimateDetail {
     private Long groomerId;
     private String imageUrl;
     private String name;
+    private Long shopId;
     private String shopName;
     private int daengleMeter;
     private Proposal proposal;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/reservation/dto/EstimateDetail.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/reservation/dto/EstimateDetail.java
@@ -22,6 +22,7 @@ public class EstimateDetail {
         private Long groomerId;
         private String imageUrl;
         private String name;
+        private Long shopId;
         private String shopName;
         private int daengleMeter;
         private List<GroomingKeyword> keywords;

--- a/daengle-vet-api/src/main/java/ddog/vet/application/AccountService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/AccountService.java
@@ -70,6 +70,13 @@ public class AccountService {
         return authentication;
     }
 
+    public ProfileInfo getVetInfo(Long accountId) {
+        Vet vet = vetPersist.findByAccountId(accountId)
+                .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));
+
+        return VetMapper.mapToProfileInfo(vet);
+    }
+
     @Transactional(readOnly = true)
     public ProfileInfo.UpdatePage getModifyPage(Long accountId) {
         Vet vet = vetPersist.findByAccountId(accountId)

--- a/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetMapper.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetMapper.java
@@ -25,9 +25,25 @@ public class VetMapper {
                 .build();
     }
 
+    public static ProfileInfo mapToProfileInfo(Vet vet) {
+        return ProfileInfo.builder()
+                .imageUrls(vet.getImageUrlList())
+                .name(vet.getName())
+                .keywords(vet.getKeywords())
+                .closedDays(vet.getClosedDays())
+                .startTime(vet.getStartTime())
+                .endTime(vet.getEndTime())
+                .phoneNumber(vet.getPhoneNumber())
+                .address(vet.getAddress())
+                .detailAddress(vet.getDetailAddress())
+                .introduction(vet.getIntroduction())
+                .daengleMeter(vet.getDaengleMeter())
+                .build();
+    }
+
     public static ProfileInfo.UpdatePage mapToUpdatePage(Vet vet) {
         return ProfileInfo.UpdatePage.builder()
-                .image(vet.getImageUrl())
+                .imageUrls(vet.getImageUrlList())
                 .name(vet.getName())
                 .startTime(vet.getStartTime())
                 .endTime(vet.getEndTime())

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/account/AccountController.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/account/AccountController.java
@@ -23,6 +23,11 @@ public class AccountController {
         return success(accountService.signUp(request, response));
     }
 
+    @GetMapping("/info")
+    public CommonResponseEntity<ProfileInfo> getVetInfo(PayloadDto payloadDto) {
+        return success(accountService.getVetInfo(payloadDto.getAccountId()));
+    }
+
     @GetMapping("/modify-page")
     public CommonResponseEntity<ProfileInfo.UpdatePage> getModifyInfo(PayloadDto payloadDto) {
         return success(accountService.getModifyPage(payloadDto.getAccountId()));

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/account/dto/ProfileInfo.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/account/dto/ProfileInfo.java
@@ -1,6 +1,8 @@
 package ddog.vet.presentation.account.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import ddog.domain.vet.Day;
+import ddog.domain.vet.enums.CareKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,13 +13,35 @@ import java.util.List;
 @Builder
 public class ProfileInfo {
 
+    private List<String> imageUrls;
+    private String name;
+    private List<CareKeyword> keywords;
+    private List<Day> closedDays;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime startTime;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime endTime;
+
+    private String phoneNumber;
+    private String address;
+    private String detailAddress;
+    private String introduction;
+    private int daengleMeter;
+
     @Getter
     @Builder
     public static class UpdatePage {
-        private String image;
+        private List<String> imageUrls;
         private String name;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
         private LocalTime startTime;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
         private LocalTime endTime;
+
         private List<Day> closedDays;
         private String phoneNumber;
         private String address;

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/account/dto/UpdateInfo.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/account/dto/UpdateInfo.java
@@ -1,5 +1,6 @@
 package ddog.vet.presentation.account.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import ddog.domain.vet.Day;
 import lombok.Getter;
 
@@ -9,8 +10,13 @@ import java.util.List;
 @Getter
 public class UpdateInfo {
     private List<String> imageUrls;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
     private LocalTime startTime;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
     private LocalTime endTime;
+
     private List<Day> closedDays;
     private String phoneNumber;
     private String introduction;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : 
    - [Notion-API] : 

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 미용사 마이페이지 정보 GET api 구현
    - 견적서 상세 페이지에서 미용사가 속한 미용실로 라우팅 하기 위한 미용실 ID 정보 추가
    - 병원 시작시간, 종료시간 유효성 검증 로직 추가
    - 병원 마이페이지 정보 GET api 구현


> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 추후 기존에 `Groomer` 가지고 있던 `shopName` 을 빼고 `shopName` 정보는 `BeautyShop` 테이블에서 가져오도록 기존 API 보완이 필요할 것 같습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
