### PR TITLE
[fix/daengle-90] 결제 요청, API 스펙 변경

### DIFF
--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/ReviewService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/ReviewService.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -40,6 +41,7 @@ public class ReviewService {
     private final UserPersist userPersist;
     private final GroomerPersist groomerPersist;
 
+    @Transactional(readOnly = true)
     public ReviewListResp findReviewList(Long accountId, int page, int size) {
         Groomer savedGroomer = groomerPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));
@@ -52,6 +54,7 @@ public class ReviewService {
         return mappingToGroomingReviewListResp(groomingReviews);
     }
 
+    @Transactional(readOnly = true)
     public ReportReviewResp reportReview(Long groomingReviewId) {
         GroomingReview savedGroomingReview = groomingReviewPersist.findByReviewId(groomingReviewId)
                 .orElseThrow(() -> new GroomingReviewException(GroomingReviewExceptionType.GROOMING_REVIEW_NOT_FOUND));
@@ -65,6 +68,7 @@ public class ReviewService {
                 .build();
     }
 
+    @Transactional
     public SubmitReportReviewResp reportReview(ReportReviewReq reportReviewReq) {
         groomerPersist.findByGroomerId(reportReviewReq.getGroomerId())
                 .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));
@@ -82,6 +86,7 @@ public class ReviewService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public ReportedReviewListResp findReportedReviewList(Long accountId, int page, int size) {
         Groomer savedGroomer = groomerPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new GroomerException(GroomerExceptionType.GROOMER_NOT_FOUND));

--- a/daengle-payment-api/src/main/java/ddog/payment/application/OrderService.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/OrderService.java
@@ -6,6 +6,9 @@ import ddog.domain.estimate.GroomingEstimate;
 import ddog.domain.estimate.port.CareEstimatePersist;
 import ddog.domain.estimate.port.GroomingEstimatePersist;
 import ddog.domain.payment.Order;
+import ddog.domain.user.User;
+import ddog.domain.user.port.UserPersist;
+import ddog.payment.application.exception.*;
 import ddog.payment.application.mapper.OrderMapper;
 import ddog.payment.application.mapper.PaymentMapper;
 import ddog.payment.presentation.dto.PostOrderInfo;
@@ -14,10 +17,6 @@ import ddog.domain.payment.enums.ServiceType;
 import ddog.domain.payment.port.OrderPersist;
 import ddog.domain.payment.port.PaymentPersist;
 import ddog.payment.application.dto.response.PostOrderResp;
-import ddog.payment.application.exception.CareEstimateException;
-import ddog.payment.application.exception.CareEstimateExceptionType;
-import ddog.payment.application.exception.GroomingEstimateException;
-import ddog.payment.application.exception.GroomingEstimateExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,18 +28,23 @@ public class OrderService {
     private final OrderPersist orderPersist;
     private final PaymentPersist paymentPersist;
 
+    private final UserPersist userPersist;
+
     private final GroomingEstimatePersist groomingEstimatePersist;
     private final CareEstimatePersist careEstimatePersist;
 
     @Transactional
     public PostOrderResp processOrder(Long accountId, PostOrderInfo postOrderInfo) {
+        User savedUser = userPersist.findByAccountId(accountId)
+                .orElseThrow(() -> new OrderException(OrderExceptionType.ORDER_USER_NOT_FOUNDED));
+
         validateEstimate(postOrderInfo.getServiceType(), postOrderInfo.getEstimateId());
         validatePostOrderInfoDataFormat(postOrderInfo);
 
-        Payment paymentToSave = PaymentMapper.createTemporaryHistoryBy(accountId, postOrderInfo);
+        Payment paymentToSave = PaymentMapper.createTemporaryHistoryBy(savedUser.getAccountId(), postOrderInfo);
         Payment SavedPayment = paymentPersist.save(paymentToSave);
 
-        Order orderToSave = OrderMapper.createBy(accountId, postOrderInfo, SavedPayment);
+        Order orderToSave = OrderMapper.createBy(savedUser, postOrderInfo, SavedPayment);
         Order savedOrder = orderPersist.save(orderToSave);
 
         return PostOrderResp.builder()
@@ -57,7 +61,6 @@ public class OrderService {
         Order.validateShopName(postOrderInfo.getShopName());
         Order.validateSchedule(postOrderInfo.getSchedule());
         Order.validatePrice(postOrderInfo.getPrice());
-        Order.validatePhoneNumber(postOrderInfo.getCustomerPhoneNumber());
         Order.validatePhoneNumber(postOrderInfo.getVisitorPhoneNumber());
     }
 

--- a/daengle-payment-api/src/main/java/ddog/payment/application/exception/OrderExceptionType.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/exception/OrderExceptionType.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum OrderExceptionType {
+    ORDER_USER_NOT_FOUNDED(HttpStatus.NOT_FOUND, 404, "존재하지 않는 유저"),
     ORDER_NOT_FOUNDED(HttpStatus.NOT_FOUND, 6001, "주문 내역 존재하지 않음");
 
     private final HttpStatus httpStatus;

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/OrderMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/OrderMapper.java
@@ -2,6 +2,7 @@ package ddog.payment.application.mapper;
 
 import ddog.domain.payment.Order;
 import ddog.domain.payment.Payment;
+import ddog.domain.user.User;
 import ddog.payment.presentation.dto.PostOrderInfo;
 
 import java.time.LocalDateTime;
@@ -9,15 +10,15 @@ import java.util.UUID;
 
 public class OrderMapper {
 
-    public static Order createBy(Long accountId, PostOrderInfo postOrderInfo, Payment payment) {
+    public static Order createBy(User user, PostOrderInfo postOrderInfo, Payment payment) {
         return Order.builder()
                 .serviceType(postOrderInfo.getServiceType())
                 .petId(postOrderInfo.getPetId())
                 .price(postOrderInfo.getPrice())
                 .estimateId(postOrderInfo.getEstimateId())
                 .orderUid(String.valueOf(UUID.randomUUID()))
-                .accountId(accountId)
-                .customerName(postOrderInfo.getCustomerName())
+                .accountId(user.getAccountId())
+                .customerName(user.getNickname())
                 .recipientId(postOrderInfo.getRecipientId())
                 .recipientImageUrl(postOrderInfo.getRecipientImageUrl())
                 .recipientName(postOrderInfo.getRecipientName())
@@ -25,7 +26,7 @@ public class OrderMapper {
                 .orderDate(LocalDateTime.now())
                 .schedule(postOrderInfo.getSchedule())
                 .visitorName(postOrderInfo.getVisitorName())
-                .customerPhoneNumber(postOrderInfo.getCustomerPhoneNumber())
+                .customerPhoneNumber(user.getPhoneNumber())
                 .visitorPhoneNumber(postOrderInfo.getVisitorPhoneNumber())
                 .payment(payment)
                 .build();

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
@@ -18,8 +18,6 @@ public class PostOrderInfo {
     private String shopName;
     private LocalDateTime schedule;
     private Long price;
-    private String customerName;
-    private String customerPhoneNumber;
     private String visitorName;
     private String visitorPhoneNumber;
 }

--- a/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/ReviewService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -38,6 +39,7 @@ public class ReviewService {
     private final UserPersist userPersist;
     private final VetPersist vetPersist;
 
+    @Transactional(readOnly = true)
     public ReviewListResp findReviewList(Long accountId, int page, int size) {
         Vet savedVet = vetPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));
@@ -48,6 +50,7 @@ public class ReviewService {
         return mappingToCareReviewListResp(careReviews);
     }
 
+    @Transactional(readOnly = true)
     public ReportReviewResp reportReview(Long careReviewId) {
         CareReview savedCareReview = careReviewPersist.findByReviewId(careReviewId)
                 .orElseThrow(() -> new CareReviewException(CareReviewExceptionType.CARE_REVIEW_RESERVATION_NOT_FOUND));
@@ -61,6 +64,7 @@ public class ReviewService {
                 .build();
     }
 
+    @Transactional
     public SubmitReportReviewResp reportReview(ReportReviewReq reportReviewReq) {
         vetPersist.findByVetId(reportReviewReq.getVetId())
                 .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));
@@ -78,6 +82,7 @@ public class ReviewService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public ReportedReviewListResp findReportedReviewList(Long accountId, int page, int size) {
         Vet savedVet = vetPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 결제 요청 API 스펙 변경에 따라 요청값을 변경했습니다.
    - 견적 상세 보기에서 유저 닉네임과 전화번로를 내려주지 않기 때문에 견적 상세보기에서 타고 들어가는 결제 요청시 
    - 해당 값들을 전달받을 수 없습니다. 해서 토큰에 들어있는 account_id를 통해 제가 DB 찔러서 해당 값들을 불러옵니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
