### PR TITLE
[feat/daengle-91] 댕글미터 도메인 설계, 댕글미터 비즈니스 로직 구현

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
@@ -31,6 +31,11 @@ public class Groomer {
     private List<License> licenses;
     private List<GroomingKeyword> keywords;
 
+
+    public void updateDaengleMeter(Integer newMeterValue) {
+        this.daengleMeter = newMeterValue;
+    }
+
     public static void validateShopName(String shopName) {
         if (shopName == null || !shopName.matches("^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9\\s]{0,19}$")) {
             throw new IllegalArgumentException("Shop name must be 1-20 characters long and can contain Korean, " +

--- a/daengle-domain/src/main/java/ddog/domain/groomer/GroomerDaengleMeter.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/GroomerDaengleMeter.java
@@ -12,6 +12,6 @@ import lombok.NoArgsConstructor;
 public class GroomerDaengleMeter {
     private Long groomerDaengleMeterId;
     private Long groomerId;
-    private Long score;
+    private Integer score;
     private Long evaluationCount;
 }

--- a/daengle-domain/src/main/java/ddog/domain/groomer/GroomerDaengleMeter.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/GroomerDaengleMeter.java
@@ -14,4 +14,29 @@ public class GroomerDaengleMeter {
     private Long groomerId;
     private Integer score;
     private Long evaluationCount;
+
+    // 새로운 리뷰에 따른 점수 업데이트
+    public void updateMeterForNewReview(Integer newScore) {
+        long totalScore = (long) score * evaluationCount + newScore;
+        evaluationCount++;
+        score = Math.toIntExact(totalScore / evaluationCount);
+    }
+
+    // 수정된 리뷰에 따른 점수 업데이트
+    public void updateMeterForModifiedReview(Integer oldScore, Integer newScore) {
+        long totalScore = (long) score * evaluationCount - oldScore + newScore;
+        score = Math.toIntExact(totalScore / evaluationCount);
+    }
+
+    // 리뷰 삭제에 따른 점수 업데이트
+    public void updateMeterForDeletedReview(Integer oldScore) {
+        if (evaluationCount <= 1) {
+            score = 0;
+            evaluationCount = 0L;
+        } else {
+            long totalScore = (long) score * evaluationCount - oldScore;
+            evaluationCount--;
+            score = Math.toIntExact(totalScore / evaluationCount);
+        }
+    }
 }

--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerDaengleMeterPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerDaengleMeterPersist.java
@@ -2,6 +2,9 @@ package ddog.domain.groomer.port;
 
 import ddog.domain.groomer.GroomerDaengleMeter;
 
+import java.util.Optional;
+
 public interface GroomerDaengleMeterPersist {
     GroomerDaengleMeter save(GroomerDaengleMeter groomerDaengleMeter);
+    Optional<GroomerDaengleMeter> findByGroomerId(Long groomerId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerDaengleMeterPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerDaengleMeterPersist.java
@@ -1,0 +1,7 @@
+package ddog.domain.groomer.port;
+
+import ddog.domain.groomer.GroomerDaengleMeter;
+
+public interface GroomerDaengleMeterPersist {
+    GroomerDaengleMeter save(GroomerDaengleMeter groomerDaengleMeter);
+}

--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
@@ -8,7 +8,7 @@ public interface GroomerPersist {
 
     Optional<Groomer> findByAccountId(Long accountId);
 
-    void save(Groomer newGroomer);
+    Groomer save(Groomer newGroomer);
 
     Optional<Groomer> findByGroomerId(Long groomerId);
 

--- a/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Reservation.java
@@ -19,7 +19,7 @@ public class Reservation {
     private Long petId;
     private ServiceType serviceType;
     private ReservationStatus reservationStatus;
-    private Long recipientId;
+    private Long recipientId;  //미용사 or 병원 pk
     private String recipientImageUrl;
     private String recipientName;
     private String shopName;

--- a/daengle-domain/src/main/java/ddog/domain/review/Review.java
+++ b/daengle-domain/src/main/java/ddog/domain/review/Review.java
@@ -18,13 +18,13 @@ public abstract class Review {
     private Long reviewerId;
     private String revieweeName;
     private String shopName;
-    private Long starRating;
+    private Integer starRating;
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedTime;
     private List<String> imageUrlList;
 
-    public static void validateStarRating(Long starRating) {
+    public static void validateStarRating(Integer starRating) {
         if (starRating == null || starRating < 1 || starRating > 5) {
             throw new IllegalArgumentException("Star rating must be between 1 and 5.");
         }

--- a/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/Vet.java
@@ -34,6 +34,10 @@ public class Vet {
     private List<String> licenses;
     private List<CareKeyword> keywords;
 
+    public void updateDaengleMeter(Integer newMeterValue) {
+        this.daengleMeter = newMeterValue;
+    }
+
     public static void validateName(String name) {
         if (name == null || name.length() < 2 || name.length() > 10 || !name.matches("^[가-힣\\s]+$")) {
             throw new IllegalArgumentException("Invalid name: must be 2-10 characters and in Korean.");

--- a/daengle-domain/src/main/java/ddog/domain/vet/VetDaengleMeter.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/VetDaengleMeter.java
@@ -12,6 +12,6 @@ import lombok.NoArgsConstructor;
 public class VetDaengleMeter {
     private Long vetDaengleMeterId;
     private Long vetId;
-    private Long score;
+    private Integer score;
     private Long evaluationCount;
 }

--- a/daengle-domain/src/main/java/ddog/domain/vet/VetDaengleMeter.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/VetDaengleMeter.java
@@ -14,4 +14,29 @@ public class VetDaengleMeter {
     private Long vetId;
     private Integer score;
     private Long evaluationCount;
+
+    // 새로운 리뷰에 따른 점수 업데이트
+    public void updateMeterForNewReview(Integer newScore) {
+        long totalScore = (long) score * evaluationCount + newScore;
+        evaluationCount++;
+        score = Math.toIntExact(totalScore / evaluationCount);
+    }
+
+    // 수정된 리뷰에 따른 점수 업데이트
+    public void updateMeterForModifiedReview(Integer oldScore, Integer newScore) {
+        long totalScore = (long) score * evaluationCount - oldScore + newScore;
+        score = Math.toIntExact(totalScore / evaluationCount);
+    }
+
+    // 리뷰 삭제에 따른 점수 업데이트
+    public void updateMeterForDeletedReview(Integer oldScore) {
+        if (evaluationCount <= 1) {
+            score = 0;
+            evaluationCount = 0L;
+        } else {
+            long totalScore = (long) score * evaluationCount - oldScore;
+            evaluationCount--;
+            score = Math.toIntExact(totalScore / evaluationCount);
+        }
+    }
 }

--- a/daengle-domain/src/main/java/ddog/domain/vet/port/VetDaengleMeterPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/port/VetDaengleMeterPersist.java
@@ -2,6 +2,9 @@ package ddog.domain.vet.port;
 
 import ddog.domain.vet.VetDaengleMeter;
 
+import java.util.Optional;
+
 public interface VetDaengleMeterPersist {
+    Optional<VetDaengleMeter> findByVetId(Long vetId);
     VetDaengleMeter save(VetDaengleMeter vetDaengleMeter);
 }

--- a/daengle-domain/src/main/java/ddog/domain/vet/port/VetDaengleMeterPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/port/VetDaengleMeterPersist.java
@@ -1,0 +1,7 @@
+package ddog.domain.vet.port;
+
+import ddog.domain.vet.VetDaengleMeter;
+
+public interface VetDaengleMeterPersist {
+    VetDaengleMeter save(VetDaengleMeter vetDaengleMeter);
+}

--- a/daengle-domain/src/main/java/ddog/domain/vet/port/VetPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/port/VetPersist.java
@@ -11,7 +11,7 @@ public interface VetPersist {
     Optional<Vet> findByAccountId(Long accountId);
     Optional<Vet> findByVetId(Long vetId);
 
-    void save(Vet vet);
+    Vet save(Vet vet);
 
     Page<Vet> findByAddress(String address, Pageable pageable);
     List<Vet> findByAddressPrefix(String addressPrefix);

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -4,12 +4,15 @@ import ddog.auth.config.jwt.JwtTokenProvider;
 import ddog.domain.account.Account;
 import ddog.domain.account.Role;
 import ddog.domain.groomer.Groomer;
+import ddog.domain.groomer.GroomerDaengleMeter;
 import ddog.domain.groomer.License;
+import ddog.domain.groomer.port.GroomerDaengleMeterPersist;
 import ddog.domain.groomer.port.LicensePersist;
 import ddog.domain.shop.BeautyShop;
 import ddog.domain.shop.port.BeautyShopPersist;
 import ddog.groomer.application.exception.account.GroomerException;
 import ddog.groomer.application.exception.account.GroomerExceptionType;
+import ddog.groomer.application.mapper.GroomerDaengleMeterMapper;
 import ddog.groomer.application.mapper.GroomerMapper;
 import ddog.groomer.presentation.account.dto.*;
 import ddog.domain.account.port.AccountPersist;
@@ -37,8 +40,11 @@ public class AccountService {
 
     private final AccountPersist accountPersist;
     private final GroomerPersist groomerPersist;
+
     private final LicensePersist licensePersist;
     private final BeautyShopPersist beautyShopPersist;
+    private final GroomerDaengleMeterPersist groomerDaengleMeterPersist;
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -65,10 +71,13 @@ public class AccountService {
         BeautyShop savedBeautyShop = existingBeautyShop.orElseGet(() -> BeautyShop.create(request.getShopName(), request.getAddress()));
 
         beautyShopPersist.save(savedBeautyShop);
-        Long shopId = beautyShopPersist.findBeautyShopByNameAndAddress(savedBeautyShop.getShopName(), savedBeautyShop.getShopAddress()).get().getShopId();;
+        Long shopId = beautyShopPersist.findBeautyShopByNameAndAddress(savedBeautyShop.getShopName(), savedBeautyShop.getShopAddress()).get().getShopId();
 
         Groomer newGroomer = GroomerMapper.create(savedAccount.getAccountId(), request, licenses, shopId);
-        groomerPersist.save(newGroomer);
+        Groomer savedGroomer =  groomerPersist.save(newGroomer);
+
+        GroomerDaengleMeter newGroomerDaengleMeter = GroomerDaengleMeterMapper.create(savedGroomer.getGroomerId());
+        groomerDaengleMeterPersist.save(newGroomerDaengleMeter);
 
         return SignUpResp.builder()
                 .accessToken(accessToken)

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerDaengleMeterMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerDaengleMeterMapper.java
@@ -1,0 +1,14 @@
+package ddog.groomer.application.mapper;
+
+import ddog.domain.groomer.GroomerDaengleMeter;
+
+public class GroomerDaengleMeterMapper {
+    public static GroomerDaengleMeter create(Long groomerId) {
+        return GroomerDaengleMeter.builder()
+                .groomerDaengleMeterId(null)
+                .groomerId(groomerId)
+                .score(50)
+                .evaluationCount(0L)
+                .build();
+    }
+}

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
@@ -13,7 +13,7 @@ public class GroomerMapper {
     public static Groomer create(Long accountId, SignUpReq request, List<License> licenses, Long shopId) {
         return Groomer.builder()
                 .accountId(accountId)
-                .daengleMeter(0)
+                .daengleMeter(50)
                 .imageUrl("")
                 .name(request.getName())
                 .phoneNumber(request.getPhoneNumber())

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/dto/PostOrderInfo.java
@@ -12,7 +12,7 @@ public class PostOrderInfo {
     private Long estimateId;
     private Long petId;
     private ServiceType serviceType;
-    private Long recipientId;
+    private Long recipientId; //미용사 or 병원 PK
     private String recipientImageUrl;
     private String recipientName;
     private String shopName;

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerDaengleMeterRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerDaengleMeterRepository.java
@@ -7,12 +7,19 @@ import ddog.persistence.mysql.jpa.repository.GroomerDaengleMeterJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class GroomerDaengleMeterRepository implements GroomerDaengleMeterPersist {
 
     private final GroomerDaengleMeterJpaRepository groomerDaengleMeterJpaRepository;
 
+    @Override
+    public Optional<GroomerDaengleMeter> findByGroomerId(Long groomerId) {
+        return groomerDaengleMeterJpaRepository.findByGroomerId(groomerId).map(GroomerDanegleMeterJpaEntity::toModel);
+    }
+    
     @Override
     public GroomerDaengleMeter save(GroomerDaengleMeter groomerDaengleMeter) {
         return groomerDaengleMeterJpaRepository.save(GroomerDanegleMeterJpaEntity.from(groomerDaengleMeter)).toModel();

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerDaengleMeterRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerDaengleMeterRepository.java
@@ -1,0 +1,20 @@
+package ddog.persistence.mysql.adapter;
+
+import ddog.domain.groomer.GroomerDaengleMeter;
+import ddog.domain.groomer.port.GroomerDaengleMeterPersist;
+import ddog.persistence.mysql.jpa.entity.GroomerDanegleMeterJpaEntity;
+import ddog.persistence.mysql.jpa.repository.GroomerDaengleMeterJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GroomerDaengleMeterRepository implements GroomerDaengleMeterPersist {
+
+    private final GroomerDaengleMeterJpaRepository groomerDaengleMeterJpaRepository;
+
+    @Override
+    public GroomerDaengleMeter save(GroomerDaengleMeter groomerDaengleMeter) {
+        return groomerDaengleMeterJpaRepository.save(GroomerDanegleMeterJpaEntity.from(groomerDaengleMeter)).toModel();
+    }
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerRepository.java
@@ -22,8 +22,8 @@ public class GroomerRepository implements GroomerPersist {
     }
 
     @Override
-    public void save(Groomer newGroomer) {
-        groomerJpaRepository.save(GroomerJpaEntity.from(newGroomer));
+    public Groomer save(Groomer newGroomer) {
+        return groomerJpaRepository.save(GroomerJpaEntity.from(newGroomer)).toModel();
     }
 
     @Override

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetDaengleMeterRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetDaengleMeterRepository.java
@@ -7,11 +7,18 @@ import ddog.persistence.mysql.jpa.repository.VetDaengleMeterJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class VetDaengleMeterRepository implements VetDaengleMeterPersist {
 
     private final VetDaengleMeterJpaRepository vetDaengleMeterJpaRepository;
+
+    @Override
+    public Optional<VetDaengleMeter> findByVetId(Long vetId) {
+        return vetDaengleMeterJpaRepository.findByVetId(vetId).map(VetDaengleMeterJpaEntity::toModel);
+    }
 
     @Override
     public VetDaengleMeter save(VetDaengleMeter vetDaengleMeter) {

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetDaengleMeterRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetDaengleMeterRepository.java
@@ -1,0 +1,20 @@
+package ddog.persistence.mysql.adapter;
+
+import ddog.domain.vet.VetDaengleMeter;
+import ddog.domain.vet.port.VetDaengleMeterPersist;
+import ddog.persistence.mysql.jpa.entity.VetDaengleMeterJpaEntity;
+import ddog.persistence.mysql.jpa.repository.VetDaengleMeterJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class VetDaengleMeterRepository implements VetDaengleMeterPersist {
+
+    private final VetDaengleMeterJpaRepository vetDaengleMeterJpaRepository;
+
+    @Override
+    public VetDaengleMeter save(VetDaengleMeter vetDaengleMeter) {
+        return vetDaengleMeterJpaRepository.save(VetDaengleMeterJpaEntity.from(vetDaengleMeter)).toModel();
+    }
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetRepository.java
@@ -32,8 +32,8 @@ public class VetRepository implements VetPersist {
     }
 
     @Override
-    public void save(Vet vet) {
-        vetJpaRepository.save(VetJpaEntity.from(vet));
+    public Vet save(Vet vet) {
+        return vetJpaRepository.save(VetJpaEntity.from(vet)).toModel();
     }
 
     @Override

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/CareReviewJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/CareReviewJpaEntity.java
@@ -26,7 +26,7 @@ public class CareReviewJpaEntity {
     private Long revieweeId;
     private String revieweeName;
     private String shopName;
-    private Long starRating;
+    private Integer starRating;
     private String content;
     private LocalDateTime createdAt;
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomerDanegleMeterJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomerDanegleMeterJpaEntity.java
@@ -21,7 +21,7 @@ public class GroomerDanegleMeterJpaEntity {
     Long groomerDaengleMeterId;
 
     Long groomerId;
-    Long score;
+    Integer score;
     Long evaluationCount;
 
     public GroomerDaengleMeter toModel() {

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomingReviewJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/GroomingReviewJpaEntity.java
@@ -26,7 +26,7 @@ public class GroomingReviewJpaEntity {
     private Long revieweeId;
     private String revieweeName;
     private String shopName;
-    private Long starRating;
+    private Integer starRating;
     private String content;
     private LocalDateTime createdAt;
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/VetDaengleMeterJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/VetDaengleMeterJpaEntity.java
@@ -21,7 +21,7 @@ public class VetDaengleMeterJpaEntity {
     Long vetDaengleMeterId;
 
     Long vetId;
-    Long score;
+    Integer score;
     Long evaluationCount;
 
     public VetDaengleMeter toModel() {

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomerDaengleMeterJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomerDaengleMeterJpaRepository.java
@@ -3,6 +3,9 @@ package ddog.persistence.mysql.jpa.repository;
 import ddog.persistence.mysql.jpa.entity.GroomerDanegleMeterJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GroomerDaengleMeterJpaRepository extends JpaRepository<GroomerDanegleMeterJpaEntity, Long> {
+    Optional<GroomerDanegleMeterJpaEntity> findByGroomerId(Long groomerId);
     GroomerDanegleMeterJpaEntity save(GroomerDanegleMeterJpaEntity groomerDanegleMeter);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomerDaengleMeterJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomerDaengleMeterJpaRepository.java
@@ -1,0 +1,8 @@
+package ddog.persistence.mysql.jpa.repository;
+
+import ddog.persistence.mysql.jpa.entity.GroomerDanegleMeterJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroomerDaengleMeterJpaRepository extends JpaRepository<GroomerDanegleMeterJpaEntity, Long> {
+    GroomerDanegleMeterJpaEntity save(GroomerDanegleMeterJpaEntity groomerDanegleMeter);
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/VetDaengleMeterJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/VetDaengleMeterJpaRepository.java
@@ -1,0 +1,8 @@
+package ddog.persistence.mysql.jpa.repository;
+
+import ddog.persistence.mysql.jpa.entity.VetDaengleMeterJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VetDaengleMeterJpaRepository extends JpaRepository<VetDaengleMeterJpaEntity, Long> {
+    VetDaengleMeterJpaEntity save(VetDaengleMeterJpaEntity vetDaengleMeter);
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/VetDaengleMeterJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/VetDaengleMeterJpaRepository.java
@@ -3,6 +3,9 @@ package ddog.persistence.mysql.jpa.repository;
 import ddog.persistence.mysql.jpa.entity.VetDaengleMeterJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface VetDaengleMeterJpaRepository extends JpaRepository<VetDaengleMeterJpaEntity, Long> {
+    Optional<VetDaengleMeterJpaEntity> findByVetId(Long vetId);
     VetDaengleMeterJpaEntity save(VetDaengleMeterJpaEntity vetDaengleMeter);
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/exception/account/GroomerExceptionType.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/exception/account/GroomerExceptionType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum GroomerExceptionType {
     INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
-    GROOMER_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "미용사가 존재하지 않음.");
+    GROOMER_DAENGLE_METER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "댕글 미터 초기값 존재하지 않음"),
+    GROOMER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "미용사가 존재하지 않음.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/daengle-user-api/src/main/java/ddog/user/application/exception/account/VetExceptionType.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/exception/account/VetExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum VetExceptionType {
     INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
+    VET_DAENGLE_METER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "댕글 미터 초기값 존재하지 않음"),
     VET_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "병원이 존재하지 않음.");
 
     private final HttpStatus httpStatus;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/PostCareReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/PostCareReviewInfo.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 public class PostCareReviewInfo {
     private Long reservationId;
-    private Long starRating;
+    private Integer starRating;
     private List<CareKeyword> careKeywordList;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/PostGroomingReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/PostGroomingReviewInfo.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 public class PostGroomingReviewInfo {
     private Long reservationId;
-    private Long starRating;
+    private Integer starRating;
     private List<GroomingKeyword> groomingKeywordList;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/UpdateCareReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/UpdateCareReviewInfo.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Builder
 @Getter
 public class UpdateCareReviewInfo {
-    private Long starRating;
+    private Integer starRating;
     private List<CareKeyword> careKeywordList;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/UpdateGroomingReviewInfo.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/dto/request/UpdateGroomingReviewInfo.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Builder
 @Getter
 public class UpdateGroomingReviewInfo {
-    private Long starRating;
+    private Integer starRating;
     private List<GroomingKeyword> groomingKeywordList;
     private String content;
     private List<String> imageUrlList;

--- a/daengle-vet-api/src/main/java/ddog/vet/application/AccountService.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/AccountService.java
@@ -5,9 +5,12 @@ import ddog.domain.account.Account;
 import ddog.domain.account.Role;
 import ddog.domain.vet.Vet;
 import ddog.domain.account.port.AccountPersist;
+import ddog.domain.vet.VetDaengleMeter;
+import ddog.domain.vet.port.VetDaengleMeterPersist;
 import ddog.domain.vet.port.VetPersist;
 import ddog.vet.application.exception.account.VetException;
 import ddog.vet.application.exception.account.VetExceptionType;
+import ddog.vet.application.mapper.VetDaengleMeterMapper;
 import ddog.vet.application.mapper.VetMapper;
 import ddog.vet.presentation.account.dto.*;
 import jakarta.servlet.http.HttpServletResponse;
@@ -31,7 +34,10 @@ import java.util.List;
 public class AccountService {
 
     private final AccountPersist accountPersist;
+
     private final VetPersist vetPersist;
+    private final VetDaengleMeterPersist vetDaengleMeterPersist;
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -42,7 +48,10 @@ public class AccountService {
         Account savedAccount = accountPersist.save(newAccount);
 
         Vet newVet = VetMapper.create(savedAccount.getAccountId(), request);
-        vetPersist.save(newVet);
+        Vet savedVet = vetPersist.save(newVet);
+
+        VetDaengleMeter vetDaengleMeterToSave = VetDaengleMeterMapper.create(savedVet.getVetId());
+        vetDaengleMeterPersist.save(vetDaengleMeterToSave);
 
         Authentication authentication = getAuthentication(savedAccount.getAccountId(), request.getEmail());
         String accessToken = jwtTokenProvider.generateToken(authentication, response);

--- a/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetDaengleMeterMapper.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetDaengleMeterMapper.java
@@ -1,0 +1,14 @@
+package ddog.vet.application.mapper;
+
+import ddog.domain.vet.VetDaengleMeter;
+
+public class VetDaengleMeterMapper {
+    public static VetDaengleMeter create(Long vetId) {
+        return VetDaengleMeter.builder()
+                .vetDaengleMeterId(null)
+                .vetId(vetId)
+                .score(50)
+                .evaluationCount(0L)
+                .build();
+    }
+}

--- a/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetMapper.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetMapper.java
@@ -12,7 +12,7 @@ public class VetMapper {
     public static Vet create(Long accountId, SignUpReq request) {
         return Vet.builder()
                 .accountId(accountId)
-                .daengleMeter(0)
+                .daengleMeter(50)
                 .name(request.getName())
                 .imageUrl("")
                 .address(request.getAddress())


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 댕글미터 도메인 설계
    - 댕글미터 평점 계산 로직 구현 (리뷰 생성/수정/삭제 시)

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 유저 반려견 특이사항과 파트너 뱃지와의 매칭을 통해 기존 댕글미터에 가산점을 부여하는 로직을 구현해야합니다. 
    - 현재 리뷰 서비스 계층의 트랙잭션 스크립트가 굉장히 비효울적입니다. 쿼리를 순차적으로 하나하나 씩 보냅니다. join 연산을 통한 쿼리 최적화가 필요합니다. 추후 반영하겠습니다

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
