### PR TITLE
[fix/daengle-104] 채팅 데이터 견적서 제외

### DIFF
--- a/daengle-chat-api/src/main/java/ddog/chat/application/ChatService.java
+++ b/daengle-chat-api/src/main/java/ddog/chat/application/ChatService.java
@@ -41,16 +41,12 @@ public class ChatService {
     private final VetPersist vetPersist;
     private final AccountPersist accountPersist;
 
-    private final GroomingEstimatePersist groomingEstimatePersist;
-    private final CareEstimatePersist careEstimatePersist;
-
     private ChatRoom startChat(Role role, Long accountId, Long otherUserId) {
         return findOrSaveChatRoom(role, accountId, otherUserId);
     }
 
     public ChatMessagesListResp getAllMessagesByRoomId(Role role, Long userAccountId, Long otherUserId) {
         ChatRoom savedChatRoom = startChat(role, userAccountId, otherUserId);
-        Long estimateId = null;
         String otherUserProfile = null;
         String otherUserName = null;
         if (role.equals(Role.DAENGLE)) {
@@ -59,25 +55,15 @@ public class ChatService {
                 Groomer savedGroomer = groomerPersist.findByAccountId(otherUserId).orElse(null);
                 otherUserProfile = (savedGroomer != null) ? savedGroomer.getImageUrl() : null;
                 otherUserName = (savedGroomer != null) ? savedGroomer.getName() : null;
-                estimateId = groomingEstimatePersist.findEstimateByUserIdAndGroomerId(userAccountId, otherUserId)
-                        .map(GroomingEstimate::getEstimateId).orElse(null);
             } else if (savedOtherUser.getRole().equals(Role.VET)) {
                 Vet savedVet = vetPersist.findByAccountId(otherUserId).orElse(null);
                 otherUserProfile = (savedVet != null) ? savedVet.getImageUrl() : null;
                 otherUserName = (savedVet != null) ? savedVet.getName() : null;
-                estimateId = careEstimatePersist.findEstimateByUserIdAndVetId(userAccountId, otherUserId)
-                        .map(CareEstimate::getEstimateId).orElse(null);
             }
         } else {
             User savedUser = userPersist.findByAccountId(otherUserId).orElse(null);
             otherUserProfile = (savedUser != null) ? savedUser.getImageUrl() : null;
             otherUserName = (savedUser != null) ? savedUser.getNickname() : null;
-            if (accountPersist.findById(userAccountId).getRole().equals(Role.GROOMER))
-                estimateId = groomingEstimatePersist.findEstimateByUserIdAndGroomerId(otherUserId, userAccountId)
-                        .map(GroomingEstimate::getEstimateId).orElse(null);
-            else if (accountPersist.findById(userAccountId).getRole().equals(Role.VET))
-                estimateId = careEstimatePersist.findEstimateByUserIdAndVetId(otherUserId, userAccountId)
-                        .map(CareEstimate::getEstimateId).orElse(null);
         }
 
         List<ChatMessage> savedMessages = chatMessagePersist.findByChatRoomId(savedChatRoom.getChatRoomId());
@@ -90,7 +76,6 @@ public class ChatService {
                     .otherName(otherUserName)
                     .otherProfile(otherUserProfile)
                     .messagesGroupedByDate(Collections.emptyList())
-                    .estimateId(estimateId)
                     .build();
         }
 
@@ -126,7 +111,6 @@ public class ChatService {
                 .otherName(otherUserName)
                 .otherProfile(otherUserProfile)
                 .messagesGroupedByDate(messagesByDate)
-                .estimateId(estimateId)
                 .build();
     }
 

--- a/daengle-chat-api/src/main/java/ddog/chat/presentation/dto/ChatMessagesListResp.java
+++ b/daengle-chat-api/src/main/java/ddog/chat/presentation/dto/ChatMessagesListResp.java
@@ -16,7 +16,6 @@ public class ChatMessagesListResp {
     private Long otherId;
     private String otherProfile;
     private String otherName;
-    private Long estimateId;
 
     private List<Map<String, Object>> messagesGroupedByDate;
 

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
@@ -35,5 +35,4 @@ public interface GroomingEstimatePersist {
 
     List<GroomingEstimate> findMyEstimatesByUserId(Long userId);
 
-    Optional<GroomingEstimate> findEstimateByUserIdAndGroomerId(Long userId, Long groomerId);
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
@@ -101,8 +101,4 @@ public class GroomingEstimateRepository implements GroomingEstimatePersist {
         return groomingEstimateJpaRepository.findGroomingEstimateJpaEntitiesByUserId(userId).stream().map(GroomingEstimateJpaEntity::toModel).toList();
     }
 
-    @Override
-    public Optional<GroomingEstimate> findEstimateByUserIdAndGroomerId(Long userId, Long groomerId) {
-        return groomingEstimateJpaRepository.findGroomingEstimateJpaEntityByUserIdAndGroomerId(userId, groomerId).map(GroomingEstimateJpaEntity::toModel);
-    }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
@@ -50,6 +50,4 @@ public interface GroomingEstimateJpaRepository extends JpaRepository<GroomingEst
     @Query("SELECT g FROM GroomingEstimates g WHERE DATE(g.reservedDate) = :today AND g.groomerId = :groomerAccountId AND g.status = :status")
     List<GroomingEstimateJpaEntity> findTodayScheduleByGroomerId(LocalDate today, Long groomerAccountId, EstimateStatus status);
 
-    Optional<GroomingEstimateJpaEntity> findGroomingEstimateJpaEntityByUserIdAndGroomerId(Long userId, Long groomerId);
-
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : X
    - [Notion-API] : X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 한 사용자가 여러 반려견을 가지고 있는 경우가 있기 때문에, 해당 사용자와 파트너가 어떤 견적서를 가지고 채팅을 하는지 확인하기 어렵기 때문에 채팅 데이터에서 견적서 아이디를 제외했습니다

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
