### PR TITLE
[fix/daengle-109] JPA 엔티티 변환 시 불필요한 SELECT 이슈

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/shop/dto/UpdateShopReq.java
+++ b/daengle-domain/src/main/java/ddog/domain/shop/dto/UpdateShopReq.java
@@ -1,4 +1,4 @@
-package ddog.groomer.presentation.account.dto;
+package ddog.domain.shop.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import ddog.domain.vet.Day;

--- a/daengle-domain/src/main/java/ddog/domain/shop/port/BeautyShopPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/shop/port/BeautyShopPersist.java
@@ -1,6 +1,7 @@
 package ddog.domain.shop.port;
 
 import ddog.domain.shop.BeautyShop;
+import ddog.domain.shop.dto.UpdateShopReq;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -17,4 +18,6 @@ public interface BeautyShopPersist {
     BeautyShop findBeautyShopById(Long shopId);
 
     Optional<BeautyShop> findBeautyShopByNameAndAddress(String name, String address);
+
+    void updateBeautyShopWithUpdateShopReq(UpdateShopReq request);
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -15,6 +15,7 @@ import ddog.domain.payment.Reservation;
 import ddog.domain.payment.enums.ReservationStatus;
 import ddog.domain.payment.port.ReservationPersist;
 import ddog.domain.shop.BeautyShop;
+import ddog.domain.shop.dto.UpdateShopReq;
 import ddog.domain.shop.port.BeautyShopPersist;
 import ddog.groomer.application.exception.account.AccountException;
 import ddog.groomer.application.exception.account.AccountExceptionType;
@@ -151,10 +152,7 @@ public class AccountService {
     public ShopInfo.UpdateResp updateShopInfo(UpdateShopReq request) {
         validateUpdateShopInfoDataFormat(request);
 
-        BeautyShop shop = beautyShopPersist.findBeautyShopById(request.getShopId());
-        BeautyShop updatedShop = BeautyShopMapper.updateShopInfoWithUpdateShopReq(shop, request);
-
-        beautyShopPersist.save(updatedShop);
+        beautyShopPersist.updateBeautyShopWithUpdateShopReq(request);
 
         return ShopInfo.UpdateResp.builder()
                 .requestResp("마이샵 정보가 성공적으로 변경되었습니다.")

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/BeautyShopMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/BeautyShopMapper.java
@@ -3,7 +3,7 @@ package ddog.groomer.application.mapper;
 import ddog.domain.groomer.Groomer;
 import ddog.domain.shop.BeautyShop;
 import ddog.groomer.presentation.account.dto.ShopInfo;
-import ddog.groomer.presentation.account.dto.UpdateShopReq;
+import ddog.domain.shop.dto.UpdateShopReq;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -69,6 +69,7 @@ public class BeautyShopMapper {
                 .startTime(request.getStartTime())
                 .endTime(request.getEndTime())
                 .closedDays(request.getClosedDays())
+                .groomers(shop.getGroomers())
                 .phoneNumber(request.getPhoneNumber())
                 .shopAddress(shop.getShopAddress())
                 .shopDetailAddress(shop.getShopDetailAddress())

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/AccountController.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/account/AccountController.java
@@ -2,9 +2,9 @@ package ddog.groomer.presentation.account;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
+import ddog.domain.shop.dto.UpdateShopReq;
 import ddog.groomer.application.AccountService;
 
-import ddog.groomer.application.mapper.BeautyShopMapper;
 import ddog.groomer.presentation.account.dto.*;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/BeautyShopRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/BeautyShopRepository.java
@@ -1,7 +1,9 @@
 package ddog.persistence.mysql.adapter;
 
 import ddog.domain.shop.BeautyShop;
+import ddog.domain.shop.dto.UpdateShopReq;
 import ddog.domain.shop.port.BeautyShopPersist;
+import ddog.domain.vet.Day;
 import ddog.persistence.mysql.jpa.entity.BeautyShopJpaEntity;
 import ddog.persistence.mysql.jpa.repository.BeautyShopJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +49,27 @@ public class BeautyShopRepository implements BeautyShopPersist {
     @Override
     public Optional<BeautyShop> findBeautyShopByNameAndAddress(String name, String address) {
         return beautyShopJpaRepository.findBeautyShopJpaEntityByShopNameAndShopAddress(name, address).map(BeautyShopJpaEntity::toModel);
+    }
+
+    @Override
+    public void updateBeautyShopWithUpdateShopReq(UpdateShopReq request) {
+        Long shopId = request.getShopId();
+
+        beautyShopJpaRepository.updateTimeAndPhoneNumberAndIntroduction(request.getStartTime(), request.getEndTime(), request.getPhoneNumber(), request.getIntroduction(), shopId);
+
+        beautyShopJpaRepository.deleteShopImagesByShopId(shopId);
+
+        List<String> imageUrlList = request.getImageUrlList();
+        for (String imageUrl : imageUrlList) {
+            beautyShopJpaRepository.createShopImagesWithImages(imageUrl, shopId);
+        }
+
+        beautyShopJpaRepository.deleteShopClosedDaysByShopId(shopId);
+
+        List<Day> closedDays = request.getClosedDays();
+        for (Day day : closedDays) {
+            beautyShopJpaRepository.createShopClosedDaysWithClosedDays(day.toString(), shopId);
+        }
     }
 
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/BeautyShopJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/BeautyShopJpaRepository.java
@@ -4,9 +4,12 @@ import ddog.persistence.mysql.jpa.entity.BeautyShopJpaEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,4 +24,26 @@ public interface BeautyShopJpaRepository extends JpaRepository<BeautyShopJpaEnti
     Optional<BeautyShopJpaEntity> findByShopId(Long id);
 
     Optional<BeautyShopJpaEntity> findBeautyShopJpaEntityByShopNameAndShopAddress(String shopName, String address);
+
+    @Modifying
+    @Query("UPDATE BeautyShops " +
+            "SET startTime = :startTime, endTime = :endTime, phoneNumber = :phoneNumber, introduction = :introduction " +
+            "WHERE shopId = :shopId")
+    void updateTimeAndPhoneNumberAndIntroduction(LocalTime startTime, LocalTime endTime, String phoneNumber, String introduction, Long shopId);
+
+    @Modifying
+    @Query(value = "DELETE FROM shop_images WHERE shop_id = :shopId", nativeQuery = true)
+    void deleteShopImagesByShopId(Long shopId);
+
+    @Modifying
+    @Query(value = "INSERT INTO shop_images (shop_id, image_url_list) VALUES (:shopId, :imageUrl)", nativeQuery = true)
+    void createShopImagesWithImages(String imageUrl, Long shopId);
+
+    @Modifying
+    @Query(value = "DELETE FROM shop_closed_days WHERE shop_id = :shopId", nativeQuery = true)
+    void deleteShopClosedDaysByShopId(Long shopId);
+
+    @Modifying
+    @Query(value = "INSERT INTO shop_closed_days (shop_id, day) VALUES (:shopId, :day)", nativeQuery = true)
+    void createShopClosedDaysWithClosedDays(String day, Long shopId);
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - JPQL과 Native Query 를 사용하여 엔티티 조회 없이 필드 및 컬렉션 업데이트
    - 불필요한 SELECT 제거 및 수정 성능 최적화

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

`BeautyShop` 엔티티의 데이터를 업데이트하는 과정에서 불필요한 SELECT 쿼리가 발생함을 확인했습니다.
현재 저희의 업데이트 코드는 먼저 수정하려는 객체를 가져온 뒤, 수정 사항만 변경한 뒤 업데이트하는 방식으로 구현했습니다.

따라서, 업데이트를 하기 위해서는 `BeautyShop` 엔티티를 조회한 후 도메인 객체로 변환하는 과정을 거쳐야합니다.
`BeautyShop` 엔티티를 조회하게 되면 사용하지도 않는 `@OneToMany` 로 매핑된 `List<Groomer>` 엔티티 객체들과 각 `Groomer` 엔티티에 Lazy 로딩된 컬렉션 필드들까지 모두 조회가 일어나 불필요한 SELECT 쿼리가 수행되는 문제를 발견했습니다.

이는 치명적인 조회 성능 저하 문제이며 데이터의 양이 많은 경우 `HikariCP Connection Timeout` 까지 발생합니다.

## 문제 원인 분석

문제의 원인은 JPA를 통해 가져온 엔티티 객체를 도메인 객체로 변환하는 과정인 `toModel()` 에서

```java
public BeautyShop toModel() {
    return BeautyShop.builder()
            .shopId(shopId)
            .shopName(shopName)
            .shopAddress(shopAddress)
            .shopDetailAddress(shopDetailAddress)
            .phoneNumber(phoneNumber)
            .imageUrl(imageUrl)
            .imageUrlList(imageUrlList)
            .groomers(groomers.stream()
                    .map(GroomerJpaEntity::toModel)
                    .toList())
            .startTime(startTime)
            .endTime(endTime)
            .closedDays(closedDays)
            .introduction(introduction)
            .build();
}
```
Lazy 로딩된 필드인 `Groomer` 에 접근하는 순간 Lazy 로딩이 초기화되며 Hibernate는 즉시 데이터를 가져오기 위해 SELECT 쿼리를 실행하게 됩니다.

## 고민했던 내용
Spring Data JPA를 사용하면서 성능 저하 없이 필요한 필드만 업데이트하는 방식을 고민했고, 엔티티 조회 없이 필요한 데이터만을 업데이트할 수 있도록 쿼리를 직접 작성하기로 결정했습니다.

## 문제 해결
**엔티티 조회 없이 Native Query 및 JPQL 활용**

Hibernate가 수행한 과정을 그대로 Native Query를 작성해줬습니다.

```java
@Modifying
@Query("UPDATE BeautyShops " +
        "SET startTime = :startTime, endTime = :endTime, phoneNumber = :phoneNumber, introduction = :introduction " +
        "WHERE shopId = :shopId")
void updateTimeAndPhoneNumberAndIntroduction(LocalTime startTime, LocalTime endTime, String phoneNumber, String introduction, Long shopId);

@Modifying
@Query(value = "DELETE FROM shop_images WHERE shop_id = :shopId", nativeQuery = true)
void deleteShopImagesByShopId(Long shopId);

@Modifying
@Query(value = "INSERT INTO shop_images (shop_id, image_url_list) VALUES (:shopId, :imageUrl)", nativeQuery = true)
void createShopImagesWithImages(String imageUrl, Long shopId);

@Modifying
@Query(value = "DELETE FROM shop_closed_days WHERE shop_id = :shopId", nativeQuery = true)
void deleteShopClosedDaysByShopId(Long shopId);

@Modifying
@Query(value = "INSERT INTO shop_closed_days (shop_id, day) VALUES (:shopId, :day)", nativeQuery = true)
void createShopClosedDaysWithClosedDays(String day, Long shopId);
```

그 결과 기존 업데이트를 위한 서비스 단에 `BeautyShop`을 가져오는 과정 없이

```java
BeautyShop shop = beautyShopPersist.findBeautyShopById(request.getShopId());
BeautyShop updatedShop = BeautyShopMapper.updateShopInfoWithUpdateShopReq(shop, request);

beautyShopPersist.save(updatedShop);
```

아래의 코드로 원하는 업데이트 기능을 수행할 수 있도록 변경했습니다.

```java
beautyShopPersist.updateBeautyShopWithUpdateShopReq(request);
```

Lazy 로딩과 도메인 변환 과정에서 발생한 이슈를 해결하면서 엔티티를 무조건 조회하는 것은 피해야 한다는 것을 느꼈으며, JPA 를 사용하는 것에 대해 조금 더 신중하게 사용해야 함을 배웠습니다.

## 추가적으로 고민해야 되는 점
아직 근본적인 이슈를 해결하지는 못했습니다. `BeautyShop` 객체 외에도 Lazy 로딩된 컬렉션 필드가 들어있는 객체를 조회해야 하는 경우 이러한 이슈가 계속해서 발생할 것입니다. 
**JPA를 통해 가져온 엔티티 객체를 도메인 객체로 매핑하는 과정**에서 발생하는 불필요한 SELECT 쿼리 요청을 어떻게 해결해야 하는지 고민이 필요하며 우리 서비스의 조회 과정에서 해당 이슈를 우선적으로 해결해야 합니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
