### PR TITLE
[feat/daengle-110] 결제 시스템, 무결성 제약조건을 활용한 멱등성 보장

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/payment/Payment.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/Payment.java
@@ -25,6 +25,7 @@ public class Payment {
     private PaymentStatus status;
     private LocalDateTime paymentDate;
     private String paymentUid;
+    private String idempotencyKey;
 
     public static final String PAYMENT_SUCCESS_STATUS = "paid";
 

--- a/daengle-domain/src/main/java/ddog/domain/payment/port/PaymentPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/payment/port/PaymentPersist.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 public interface PaymentPersist {
     Optional<Payment> findByPaymentId(Long paymentId);
     Payment save(Payment payment);
+    Optional<Payment> findByIdempotencyKey(String idempotencyKey);
 }

--- a/daengle-payment-api/src/main/java/ddog/payment/application/OrderService.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/OrderService.java
@@ -50,7 +50,7 @@ public class OrderService {
             validateEstimate(postOrderInfo.getServiceType(), postOrderInfo.getEstimateId());
             validatePostOrderInfoDataFormat(postOrderInfo);
 
-            Payment paymentToSave = PaymentMapper.createTemporaryHistoryBy(savedUser.getAccountId(), postOrderInfo);
+            Payment paymentToSave = PaymentMapper.createTemporaryHistoryBy(idempotencyKey, savedUser.getAccountId(), postOrderInfo);
             Payment SavedPayment = paymentPersist.save(paymentToSave);
 
             Order orderToSave = OrderMapper.createBy(idempotencyKey, savedUser, postOrderInfo, SavedPayment);

--- a/daengle-payment-api/src/main/java/ddog/payment/application/exception/PaymentExceptionType.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/exception/PaymentExceptionType.java
@@ -9,9 +9,10 @@ public enum PaymentExceptionType {
     PAYMENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "결제자 찾을 수 없음"),
     PAYMENT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "결제 내역 찾을 수 없음"),
     PAYMENT_RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "예약 내역 찾을 수 없음"),
+    PAYMENT_ALREADY_PROCESSED(HttpStatus.CONFLICT, 409, "중복된 결제 검증 요청"),
     PAYMENT_PG_INTEGRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "결제 정보 조회 중 에러 발생"),
     PAYMENT_PG_INCOMPLETE(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "미완료된 결제건"),
-    PAYMENT_ALREADY_COMPLETED(HttpStatus.NOT_FOUND, 5003, "이미 완료된 결제건"),
+    PAYMENT_ALREADY_COMPLETED(HttpStatus.NOT_FOUND, 5003, "이미 결제된 결제건"),
     PAYMENT_PG_AMOUNT_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, 5004, "결제 금액 불일치"),
     PAYMENT_CANCEL_BATCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5005, "예약 취소 배치 처리 중 에러 발생");
 

--- a/daengle-payment-api/src/main/java/ddog/payment/application/mapper/PaymentMapper.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/mapper/PaymentMapper.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 public class PaymentMapper {
 
-    public static Payment createTemporaryHistoryBy(Long accountId, PostOrderInfo postOrderInfo) {
+    public static Payment createTemporaryHistoryBy(String idempotencyKey, Long accountId, PostOrderInfo postOrderInfo) {
         return Payment.builder()
                 .paymentId(null)
                 .payerId(accountId)
@@ -16,6 +16,7 @@ public class PaymentMapper {
                 .status(PaymentStatus.PAYMENT_READY)
                 .paymentDate(LocalDateTime.now())
                 .paymentUid(null)
+                .idempotencyKey(idempotencyKey)
                 .build();
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/PaymentRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/PaymentRepository.java
@@ -26,4 +26,9 @@ import java.util.Optional;
             PaymentJpaEntity paymentJpaEntity = paymentJpaRepository.save(PaymentJpaEntity.from(payment));
             return paymentJpaEntity.toModel();
         }
+
+    @Override
+    public Optional<Payment> findByIdempotencyKey(String idempotencyKey) {
+        return paymentJpaRepository.findByIdempotencyKey(idempotencyKey).map(PaymentJpaEntity::toModel);
+    }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/PaymentJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/PaymentJpaEntity.java
@@ -15,6 +15,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity(name = "Payments")
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "idempotencyKey") // 멱등성 키 유니크 제약조건
+        }
+)
 public class PaymentJpaEntity {
 
     @Id
@@ -27,6 +32,9 @@ public class PaymentJpaEntity {
     private LocalDateTime paymentDate;
     private String paymentUid;
 
+    @Column(nullable = false, unique = true)
+    private String idempotencyKey; // 멱등성 키 필드
+
     public Payment toModel() {
         return Payment.builder()
                 .paymentId(this.paymentId)
@@ -35,6 +43,7 @@ public class PaymentJpaEntity {
                 .status(this.status)
                 .paymentDate(this.paymentDate)
                 .paymentUid(this.paymentUid)
+                .idempotencyKey(this.idempotencyKey)
                 .build();
     }
 
@@ -46,6 +55,7 @@ public class PaymentJpaEntity {
                 .status(payment.getStatus())
                 .paymentDate(payment.getPaymentDate())
                 .paymentUid(payment.getPaymentUid())
+                .idempotencyKey(payment.getIdempotencyKey())
                 .build();
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/PaymentJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/PaymentJpaRepository.java
@@ -1,6 +1,5 @@
 package ddog.persistence.mysql.jpa.repository;
 
-
 import ddog.persistence.mysql.jpa.entity.PaymentJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +7,5 @@ import java.util.Optional;
 
 public interface PaymentJpaRepository extends JpaRepository<PaymentJpaEntity, Long> {
     Optional<PaymentJpaEntity> findByPaymentId(Long paymentId);
+    Optional<PaymentJpaEntity> findByIdempotencyKey(String idempotencyKey);
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - https://docs.tosspayments.com/blog/what-is-idempotency

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?
```
결제 시스템은 안정성과 신뢰성이 가장 중요한 요소입니다. 특히 네트워크 타임아웃이나 클라이언트 재시도로 인해 중복 결제가 발생하면 경제적인 문제로 번집니다. 그래서
• 초기 시스템에서는 멱등성 키를 헤더에서 받고, 애플리케이션 레벨에서 중복 검증을 수행했습니다.
• 요청이 들어오면 데이터베이스를 조회하여 멱등성 키가 존재하는지 확인.
• 존재하지 않으면 데이터를 INSERT.

하지만 멀티스레드 환경인 mySQL 프로그램의 특징으로 인해 다음과 같은 Race Condition이 발생했습니다:
• 두 개의 요청 A와 B가 동시에 들어와 데이터베이스를 조회합니다.
• 두 요청 모두 멱등성 키가 존재하지 않는 것으로 판단하고 INSERT를 시도합니다.
• 결과적으로 중복 결제가 발생합니다.  

해결은 다음과 같이 했습니다.
• 멱등성 키를 데이터베이스 테이블의 UNIQUE 제약 조건으로 설정합니다.
• 애플리케이션에서 동시에 같은 멱등성 키를 멤버필드로 한 결제건이 들어오면 데이터베이스에서 무결성 제약 조건으로 예외가 발생시킵니다.
• 결국 애플리케이션에서 발생한 중복 삽입 시도는 한 작업을 제외하고 모두 롤백됩니다.
```






> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - API 게이트웨이를 도입한다면 멱등성키를 캐싱해두고 이곳을 조회하여, 도메인 서버까지 가지 전에 중복 요청을 막고 일관된(멱등한) 응답을 할 수 있습니다. 시간상 설계까지만 이해했습니다.
![스크린샷 2024-12-18 오전 1 35 37](https://github.com/user-attachments/assets/f467be58-3f04-439a-bd90-cdfaa36e95d5)

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : YES (payment, order)
> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
