### PR TITLE
[feat/daengle-112] 브랜치 전략을 활용한 api 모듈별 CD 워크플로우 구현 ( + git diff 방식)

### DIFF
--- a/.github/workflows/dev-deploy-chat.yml
+++ b/.github/workflows/dev-deploy-chat.yml
@@ -1,0 +1,132 @@
+name: Deploy to Develop EC2
+on:
+  push:
+    branches: [ "develop-chat" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        module:
+          - name : daengle-chat
+            path : daengle-chat-api
+            ssh_host_var: SSH_CHAT_HOST
+      max-parallel: 1
+
+    env:
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_CHAT_HOST : ${{ secrets.SSH_CHAT_HOST }}
+
+    steps:
+      # 1. Checkout Repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. Create application.yml
+      - name: Create application.yml
+        run: |
+          mkdir -p ${{ matrix.module.path }}/src/main/resources
+          echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
+
+      # 3. Create .env file
+      - name: Create .env file
+        run: |
+          echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ matrix.module.path }}/.env
+
+      # 4. Set up JDK and Build JAR
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build JAR with Gradle
+        run: |
+          ./gradlew clean :${{ matrix.module.path }}:build -x test
+
+      # 5. Verify Build Output
+      - name: Verify Build Output
+        run: ls -lh ${{ matrix.module.path }}/build/libs
+
+      # 6. Log in to Amazon ECR
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_ROOT_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_ROOT_SECRET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+      # 7. Build and Push Docker Image
+      - name: Build and Push Docker Image
+        run: |
+          set -e
+          cd ${{ matrix.module.path }}
+          
+          IMAGE_TAG="${{ matrix.module.name }}-$(date +%Y%m%d%H%M%S)"
+          
+          echo "Building Docker image..."
+          docker build --platform linux/amd64 --build-arg JAR_FILE=build/libs/${{ matrix.module.name }}-api-0.0.1-SNAPSHOT.jar -t ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG .
+          docker tag ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG ${{ secrets.ECR_REPOSITORY_URI }}:latest
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
+
+      # 8. Set up SSH
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+      # 9. Set up EC2 Host from Secrets
+      - name: Set up EC2 Host
+        run: |
+          EC2_HOST=${{ secrets[ matrix.module.ssh_host_var ] }}
+          echo "Resolved EC2_HOST: $EC2_HOST"
+          echo "EC2_HOST=$EC2_HOST" >> $GITHUB_ENV
+
+      # 10. Deploy to EC2
+      - name: Deploy to EC2
+        run: |
+          set -e
+          echo "=== Logging into EC2 ==="
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@${EC2_HOST} << 'EOF'
+          
+          # EC2에서 AWS 인증 정보 설정
+          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+          export AWS_REGION="${{ secrets.AWS_REGION }}"
+          
+           # AWS ECR에 로그인
+          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
+          
+          MODULE=${{ matrix.module.name }}
+          IMAGE_TAG=${IMAGE_TAG}
+          CONTAINER_NAME="${{matrix.module.name}}-container"
+          
+          echo "=== Cleaning up old Docker images ==="
+          # 최신 6개 이미지를 제외한 나머지 삭제
+          IMAGE_COUNT=$(docker images -q | wc -l)
+          if [ "$IMAGE_COUNT" -gt 6 ]; then
+          echo "Deleting old images, keeping the latest 6..."
+          docker images -q | tail -n +7 | xargs -r docker rmi -f
+          else
+          echo "No old images to delete. Current image count: $IMAGE_COUNT"
+          fi
+          
+          # Pull latest image
+          docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker pull failed"; exit 1; }
+          
+          echo "=== Verifying Docker images ==="
+          docker images  
+
+          echo "=== Stopping and removing existing container ==="
+          docker ps --filter "name=$CONTAINER_NAME" | grep $CONTAINER_NAME && docker stop $CONTAINER_NAME && docker rm $CONTAINER_NAME || echo "No running container to stop."
+          docker ps -a --filter "name=$CONTAINER_NAME" -q | xargs -r docker stop | xargs -r docker rm || echo "No running container to stop."
+
+          echo "=== Running new container ==="
+          docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker run failed"; exit 1; }
+
+          echo "=== Deployment completed successfully ==="

--- a/.github/workflows/dev-deploy-diff.yml
+++ b/.github/workflows/dev-deploy-diff.yml
@@ -129,37 +129,44 @@ jobs:
       - name: Build and Push Docker Image
         if: steps.skip-check.outputs.deploy == 'true'
         run: |
+          set -e
+          cd ${{ matrix.module.path }}  # Dockerfile이 있는 디렉토리로 이동
+          
+          # Docker 이미지 태그 설정
           IMAGE_TAG="${{ matrix.module.name }}-$(date +%Y%m%d%H%M%S)"
+          echo "Building Docker image with tag: $IMAGE_TAG"
+          
+          # Docker 이미지 빌드 및 푸시
           docker build --platform linux/amd64 --build-arg JAR_FILE=build/libs/${{ matrix.module.name }}-api-0.0.1-SNAPSHOT.jar -t ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG .
           docker tag ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG ${{ secrets.ECR_REPOSITORY_URI }}:latest
           docker push ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG
           docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
-
-      # Deploy to EC2
-      - name: Set up SSH
-        if: steps.skip-check.outputs.deploy == 'true'
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          echo "StrictHostKeyChecking no" >> ~/.ssh/config
-
-      - name: Deploy to EC2
-        if: steps.skip-check.outputs.deploy == 'true'
-        run: |
-          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@$EC2_HOST << 'EOF'
-            export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
-            export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-            export AWS_REGION="${{ secrets.AWS_REGION }}"
-            aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
-
-            CONTAINER_NAME="${{ matrix.module.name }}-container"
-            docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest
-            docker stop $CONTAINER_NAME || true
-            docker rm $CONTAINER_NAME || true
-            docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest
-          EOF
-
-      - name: Deployment Complete
-        if: steps.skip-check.outputs.deploy == 'true'
-        run: echo "Deployment for ${{ matrix.module.name }} completed successfully!"
+          
+          # Deploy to EC2
+          - name: Set up SSH
+            if: steps.skip-check.outputs.deploy == 'true'
+            run: |
+              mkdir -p ~/.ssh
+              echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+              chmod 600 ~/.ssh/id_rsa
+              echo "StrictHostKeyChecking no" >> ~/.ssh/config
+          
+          - name: Deploy to EC2
+            if: steps.skip-check.outputs.deploy == 'true'
+            run: |
+              ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@$EC2_HOST << 'EOF'
+                export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+                export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+                export AWS_REGION="${{ secrets.AWS_REGION }}"
+                aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
+          
+                CONTAINER_NAME="${{ matrix.module.name }}-container"
+                docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest
+                docker stop $CONTAINER_NAME || true
+                docker rm $CONTAINER_NAME || true
+                docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest
+              EOF
+          
+          - name: Deployment Complete
+            if: steps.skip-check.outputs.deploy == 'true'
+            run: echo "Deployment for ${{ matrix.module.name }} completed successfully!"

--- a/.github/workflows/dev-deploy-diff.yml
+++ b/.github/workflows/dev-deploy-diff.yml
@@ -1,0 +1,84 @@
+name: Deploy to Develop EC2
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ] #테스트 용
+
+jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      all_modules: ${{ steps.changes.outputs.all_modules }}
+      daengle-chat: ${{ steps.changes.outputs.daengle-chat }}
+      daengle-groomer: ${{ steps.changes.outputs.daengle-groomer }}
+      daengle-payment: ${{ steps.changes.outputs.daengle-payment }}
+      daengle-user: ${{ steps.changes.outputs.daengle-user }}
+      daengle-vet: ${{ steps.changes.outputs.daengle-vet }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for changes
+        id: changes
+        run: |
+          # 모든 모듈을 재배포해야 하는 공통 모듈 감지
+          if git diff --name-only HEAD^ HEAD | grep -E 'daengle-auth|daengle-domain|daengle-notification|daengle-persistence-(mysql|dynamodb)'; then
+            echo "all_modules=true" >> $GITHUB_OUTPUT
+          fi
+
+          # 개별 모듈 변경 감지
+          for module in daengle-chat-api daengle-groomer-api daengle-payment-api daengle-user-api daengle-vet-api; do
+            if git diff --name-only HEAD^ HEAD | grep -E "$module"; then
+              echo "${module/-api/}=true" >> $GITHUB_OUTPUT
+            fi
+          done
+
+  deploy:
+    needs: check-changes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module:
+          - name: daengle-chat
+            path: daengle-chat-api
+            ssh_host_var: SSH_CHAT_HOST
+          - name: daengle-groomer
+            path: daengle-groomer-api
+            ssh_host_var: SSH_GROOMER_HOST
+          - name: daengle-payment
+            path: daengle-payment-api
+            ssh_host_var: SSH_PAYMENT_HOST
+          - name: daengle-user
+            path: daengle-user-api
+            ssh_host_var: SSH_USER_HOST
+          - name: daengle-vet
+            path: daengle-vet-api
+            ssh_host_var: SSH_VET_HOST
+      max-parallel: 1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Skip Unchanged Modules
+        if: needs.check-changes.outputs.all_modules != 'true' && needs.check-changes.outputs[matrix.module.name] != 'true'
+        run: echo "No changes detected in ${{ matrix.module.name }}. Skipping deployment."
+
+      - name: Create application.yml
+        if: needs.check-changes.outputs.all_modules == 'true' || needs.check-changes.outputs[matrix.module.name] == 'true'
+        run: |
+          mkdir -p ${{ matrix.module.path }}/src/main/resources
+          echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
+
+      # 이어지는 나머지 Steps들은 동일하게 실행
+      - name: Build JAR
+        if: needs.check-changes.outputs.all_modules == 'true' || needs.check-changes.outputs[matrix.module.name] == 'true'
+        run: ./gradlew clean :${{ matrix.module.path }}:build -x test
+
+      - name: Deploy to EC2
+        if: needs.check-changes.outputs.all_modules == 'true' || needs.check-changes.outputs[matrix.module.name] == 'true'
+        run: |
+          # SSH를 통한 배포 실행
+          echo "Deploying ${{ matrix.module.name }}"

--- a/.github/workflows/dev-deploy-diff.yml
+++ b/.github/workflows/dev-deploy-diff.yml
@@ -25,11 +25,10 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          # 기준 브랜치와 현재 상태의 전체 변경 사항 비교
           CHANGED_FILES=$(git diff --name-only origin/develop...HEAD)
           echo "Changed files: $CHANGED_FILES"
 
-          # 공통 모듈 감지: 변경 시 모든 모듈 재배포
+          # 공통 모듈 감지: 모든 모듈 재배포
           if echo "$CHANGED_FILES" | grep -E 'daengle-auth|daengle-domain|daengle-notification|daengle-persistence-(mysql|dynamodb)'; then
             echo "all_modules=true" >> $GITHUB_OUTPUT
           else
@@ -54,19 +53,14 @@ jobs:
         module:
           - name: daengle-chat
             path: daengle-chat-api
-            ssh_host_var: SSH_CHAT_HOST
           - name: daengle-groomer
             path: daengle-groomer-api
-            ssh_host_var: SSH_GROOMER_HOST
           - name: daengle-payment
             path: daengle-payment-api
-            ssh_host_var: SSH_PAYMENT_HOST
           - name: daengle-user
             path: daengle-user-api
-            ssh_host_var: SSH_USER_HOST
           - name: daengle-vet
             path: daengle-vet-api
-            ssh_host_var: SSH_VET_HOST
       max-parallel: 1
 
     steps:
@@ -88,27 +82,71 @@ jobs:
         if: steps.skip-check.outputs.deploy == 'false'
         run: echo "No changes detected in ${{ matrix.module.name }}. Skipping deployment."
 
-      # 변경사항이 있는 경우 배포 실행
-      - name: Create application.yml
+      # EC2 서버 호스트 설정
+      - name: Resolve EC2 Host
         if: steps.skip-check.outputs.deploy == 'true'
+        id: resolve-host
         run: |
-          mkdir -p ${{ matrix.module.path }}/src/main/resources
-          echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
+          case "${{ matrix.module.name }}" in
+            "daengle-chat")
+              echo "EC2_HOST=${{ secrets.SSH_CHAT_HOST }}" >> $GITHUB_ENV
+              ;;
+            "daengle-groomer")
+              echo "EC2_HOST=${{ secrets.SSH_GROOMER_HOST }}" >> $GITHUB_ENV
+              ;;
+            "daengle-payment")
+              echo "EC2_HOST=${{ secrets.SSH_PAYMENT_HOST }}" >> $GITHUB_ENV
+              ;;
+            "daengle-user")
+              echo "EC2_HOST=${{ secrets.SSH_USER_HOST }}" >> $GITHUB_ENV
+              ;;
+            "daengle-vet")
+              echo "EC2_HOST=${{ secrets.SSH_VET_HOST }}" >> $GITHUB_ENV
+              ;;
+          esac
+          echo "Resolved EC2_HOST: $EC2_HOST"
+
+      # Build 및 Docker Push
+      - name: Set up JDK 17
+        if: steps.skip-check.outputs.deploy == 'true'
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Build JAR
         if: steps.skip-check.outputs.deploy == 'true'
         run: ./gradlew clean :${{ matrix.module.path }}:build -x test
 
-      - name: Deploy to EC2
+      - name: Log in to Amazon ECR
+        if: steps.skip-check.outputs.deploy == 'true'
+        uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_ROOT_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_ROOT_SECRET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+      - name: Build and Push Docker Image
         if: steps.skip-check.outputs.deploy == 'true'
         run: |
-          echo "Deploying ${{ matrix.module.name }}"
+          IMAGE_TAG="${{ matrix.module.name }}-$(date +%Y%m%d%H%M%S)"
+          docker build --platform linux/amd64 --build-arg JAR_FILE=build/libs/${{ matrix.module.name }}-api-0.0.1-SNAPSHOT.jar -t ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG .
+          docker tag ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG ${{ secrets.ECR_REPOSITORY_URI }}:latest
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
+
+      # Deploy to EC2
+      - name: Set up SSH
+        if: steps.skip-check.outputs.deploy == 'true'
+        run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           echo "StrictHostKeyChecking no" >> ~/.ssh/config
 
-          EC2_HOST=${{ secrets[matrix.module.ssh_host_var] }}
+      - name: Deploy to EC2
+        if: steps.skip-check.outputs.deploy == 'true'
+        run: |
           ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@$EC2_HOST << 'EOF'
             export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
             export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"

--- a/.github/workflows/dev-deploy-diff.yml
+++ b/.github/workflows/dev-deploy-diff.yml
@@ -2,9 +2,7 @@ name: Deploy to Develop EC2
 
 on:
   push:
-    branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ] # 테스트 용
+    branches: [ "NONE" ]
 
 jobs:
   check-changes:
@@ -25,16 +23,15 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
+          # 기준 브랜치와 현재 상태의 전체 변경 사항 비교
           CHANGED_FILES=$(git diff --name-only origin/develop...HEAD)
           echo "Changed files: $CHANGED_FILES"
-
-          # 공통 모듈 감지: 모든 모듈 재배포
+          # 공통 모듈 감지: 변경 시 모든 모듈 재배포
           if echo "$CHANGED_FILES" | grep -E 'daengle-auth|daengle-domain|daengle-notification|daengle-persistence-(mysql|dynamodb)'; then
             echo "all_modules=true" >> $GITHUB_OUTPUT
           else
             echo "all_modules=false" >> $GITHUB_OUTPUT
           fi
-
           # 개별 모듈 감지
           for module in daengle-chat-api daengle-groomer-api daengle-payment-api daengle-user-api daengle-vet-api; do
             MODULE_NAME="${module/-api/}"
@@ -44,7 +41,6 @@ jobs:
               echo "$MODULE_NAME=false" >> $GITHUB_OUTPUT
             fi
           done
-
   deploy:
     needs: check-changes
     runs-on: ubuntu-latest
@@ -53,14 +49,19 @@ jobs:
         module:
           - name: daengle-chat
             path: daengle-chat-api
+            ssh_host_var: SSH_CHAT_HOST
           - name: daengle-groomer
             path: daengle-groomer-api
+            ssh_host_var: SSH_GROOMER_HOST
           - name: daengle-payment
             path: daengle-payment-api
+            ssh_host_var: SSH_PAYMENT_HOST
           - name: daengle-user
             path: daengle-user-api
+            ssh_host_var: SSH_USER_HOST
           - name: daengle-vet
             path: daengle-vet-api
+            ssh_host_var: SSH_VET_HOST
       max-parallel: 1
 
     steps:
@@ -76,97 +77,41 @@ jobs:
           else
             echo "deploy=false" >> $GITHUB_OUTPUT
           fi
-
       # 변경사항이 없는 경우 스킵
       - name: Skip Unchanged Modules
         if: steps.skip-check.outputs.deploy == 'false'
         run: echo "No changes detected in ${{ matrix.module.name }}. Skipping deployment."
 
-      # EC2 서버 호스트 설정
-      - name: Resolve EC2 Host
+      # 변경사항이 있는 경우 배포 실행
+      - name: Create application.yml
         if: steps.skip-check.outputs.deploy == 'true'
-        id: resolve-host
         run: |
-          case "${{ matrix.module.name }}" in
-            "daengle-chat")
-              echo "EC2_HOST=${{ secrets.SSH_CHAT_HOST }}" >> $GITHUB_ENV
-              ;;
-            "daengle-groomer")
-              echo "EC2_HOST=${{ secrets.SSH_GROOMER_HOST }}" >> $GITHUB_ENV
-              ;;
-            "daengle-payment")
-              echo "EC2_HOST=${{ secrets.SSH_PAYMENT_HOST }}" >> $GITHUB_ENV
-              ;;
-            "daengle-user")
-              echo "EC2_HOST=${{ secrets.SSH_USER_HOST }}" >> $GITHUB_ENV
-              ;;
-            "daengle-vet")
-              echo "EC2_HOST=${{ secrets.SSH_VET_HOST }}" >> $GITHUB_ENV
-              ;;
-          esac
-          echo "Resolved EC2_HOST: $EC2_HOST"
-
-      # Build 및 Docker Push
-      - name: Set up JDK 17
-        if: steps.skip-check.outputs.deploy == 'true'
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
+          mkdir -p ${{ matrix.module.path }}/src/main/resources
+          echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
       - name: Build JAR
         if: steps.skip-check.outputs.deploy == 'true'
         run: ./gradlew clean :${{ matrix.module.path }}:build -x test
 
-      - name: Log in to Amazon ECR
-        if: steps.skip-check.outputs.deploy == 'true'
-        uses: aws-actions/amazon-ecr-login@v2
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_ROOT_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_ROOT_SECRET }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-
-      - name: Build and Push Docker Image
+      - name: Deploy to EC2
         if: steps.skip-check.outputs.deploy == 'true'
         run: |
-          set -e
-          cd ${{ matrix.module.path }}  # Dockerfile이 있는 디렉토리로 이동
-          
-          # Docker 이미지 태그 설정
-          IMAGE_TAG="${{ matrix.module.name }}-$(date +%Y%m%d%H%M%S)"
-          echo "Building Docker image with tag: $IMAGE_TAG"
-          
-          # Docker 이미지 빌드 및 푸시
-          docker build --platform linux/amd64 --build-arg JAR_FILE=build/libs/${{ matrix.module.name }}-api-0.0.1-SNAPSHOT.jar -t ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG .
-          docker tag ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG ${{ secrets.ECR_REPOSITORY_URI }}:latest
-          docker push ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG
-          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
-          
-          # Deploy to EC2
-          - name: Set up SSH
-            if: steps.skip-check.outputs.deploy == 'true'
-            run: |
-              mkdir -p ~/.ssh
-              echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-              chmod 600 ~/.ssh/id_rsa
-              echo "StrictHostKeyChecking no" >> ~/.ssh/config
-          
-          - name: Deploy to EC2
-            if: steps.skip-check.outputs.deploy == 'true'
-            run: |
-              ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@$EC2_HOST << 'EOF'
-                export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
-                export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-                export AWS_REGION="${{ secrets.AWS_REGION }}"
-                aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
-          
-                CONTAINER_NAME="${{ matrix.module.name }}-container"
-                docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest
-                docker stop $CONTAINER_NAME || true
-                docker rm $CONTAINER_NAME || true
-                docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest
-              EOF
-          
-          - name: Deployment Complete
-            if: steps.skip-check.outputs.deploy == 'true'
-            run: echo "Deployment for ${{ matrix.module.name }} completed successfully!"
+          echo "Deploying ${{ matrix.module.name }}"
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+          EC2_HOST=${{ secrets[matrix.module.ssh_host_var] }}
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@$EC2_HOST << 'EOF'
+            export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+            export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            export AWS_REGION="${{ secrets.AWS_REGION }}"
+            aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
+            CONTAINER_NAME="${{ matrix.module.name }}-container"
+            docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest
+            docker stop $CONTAINER_NAME || true
+            docker rm $CONTAINER_NAME || true
+            docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest
+          EOF
+      - name: Deployment Complete
+        if: steps.skip-check.outputs.deploy == 'true'
+        run: echo "Deployment for ${{ matrix.module.name }} completed successfully!"

--- a/.github/workflows/dev-deploy-diff.yml
+++ b/.github/workflows/dev-deploy-diff.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "develop" ]
   pull_request:
-    branches: [ "develop" ] #테스트 용
+    branches: [ "develop" ] # 테스트 용
 
 jobs:
   check-changes:
@@ -19,19 +19,30 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 전체 Git 히스토리 가져오기
 
       - name: Check for changes
         id: changes
         run: |
-          # 모든 모듈을 재배포해야 하는 공통 모듈 감지
-          if git diff --name-only HEAD^ HEAD | grep -E 'daengle-auth|daengle-domain|daengle-notification|daengle-persistence-(mysql|dynamodb)'; then
+          # 기준 브랜치와 현재 상태의 전체 변경 사항 비교
+          CHANGED_FILES=$(git diff --name-only origin/develop...HEAD)
+          echo "Changed files: $CHANGED_FILES"
+
+          # 공통 모듈 감지: 변경 시 모든 모듈 재배포
+          if echo "$CHANGED_FILES" | grep -E 'daengle-auth|daengle-domain|daengle-notification|daengle-persistence-(mysql|dynamodb)'; then
             echo "all_modules=true" >> $GITHUB_OUTPUT
+          else
+            echo "all_modules=false" >> $GITHUB_OUTPUT
           fi
 
-          # 개별 모듈 변경 감지
+          # 개별 모듈 감지
           for module in daengle-chat-api daengle-groomer-api daengle-payment-api daengle-user-api daengle-vet-api; do
-            if git diff --name-only HEAD^ HEAD | grep -E "$module"; then
-              echo "${module/-api/}=true" >> $GITHUB_OUTPUT
+            MODULE_NAME="${module/-api/}"
+            if echo "$CHANGED_FILES" | grep -E "$module"; then
+              echo "$MODULE_NAME=true" >> $GITHUB_OUTPUT
+            else
+              echo "$MODULE_NAME=false" >> $GITHUB_OUTPUT
             fi
           done
 
@@ -62,23 +73,55 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # 변경된 모듈 여부 확인
+      - name: Check Deployment Condition
+        id: skip-check
+        run: |
+          if [[ "${{ needs.check-changes.outputs.all_modules }}" == "true" || "${{ needs.check-changes.outputs[matrix.module.name] }}" == "true" ]]; then
+            echo "deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "deploy=false" >> $GITHUB_OUTPUT
+          fi
+
+      # 변경사항이 없는 경우 스킵
       - name: Skip Unchanged Modules
-        if: needs.check-changes.outputs.all_modules != 'true' && needs.check-changes.outputs[matrix.module.name] != 'true'
+        if: steps.skip-check.outputs.deploy == 'false'
         run: echo "No changes detected in ${{ matrix.module.name }}. Skipping deployment."
 
+      # 변경사항이 있는 경우 배포 실행
       - name: Create application.yml
-        if: needs.check-changes.outputs.all_modules == 'true' || needs.check-changes.outputs[matrix.module.name] == 'true'
+        if: steps.skip-check.outputs.deploy == 'true'
         run: |
           mkdir -p ${{ matrix.module.path }}/src/main/resources
           echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
 
-      # 이어지는 나머지 Steps들은 동일하게 실행
       - name: Build JAR
-        if: needs.check-changes.outputs.all_modules == 'true' || needs.check-changes.outputs[matrix.module.name] == 'true'
+        if: steps.skip-check.outputs.deploy == 'true'
         run: ./gradlew clean :${{ matrix.module.path }}:build -x test
 
       - name: Deploy to EC2
-        if: needs.check-changes.outputs.all_modules == 'true' || needs.check-changes.outputs[matrix.module.name] == 'true'
+        if: steps.skip-check.outputs.deploy == 'true'
         run: |
-          # SSH를 통한 배포 실행
           echo "Deploying ${{ matrix.module.name }}"
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+          EC2_HOST=${{ secrets[matrix.module.ssh_host_var] }}
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@$EC2_HOST << 'EOF'
+            export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+            export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            export AWS_REGION="${{ secrets.AWS_REGION }}"
+            aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
+
+            CONTAINER_NAME="${{ matrix.module.name }}-container"
+            docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest
+            docker stop $CONTAINER_NAME || true
+            docker rm $CONTAINER_NAME || true
+            docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest
+          EOF
+
+      - name: Deployment Complete
+        if: steps.skip-check.outputs.deploy == 'true'
+        run: echo "Deployment for ${{ matrix.module.name }} completed successfully!"

--- a/.github/workflows/dev-deploy-groomer.yml
+++ b/.github/workflows/dev-deploy-groomer.yml
@@ -1,0 +1,132 @@
+name: Deploy to Develop EC2
+on:
+  push:
+    branches: [ "develop-groomer" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        module:
+          - name: daengle-groomer
+            path: daengle-groomer-api
+            ssh_host_var: SSH_GROOMER_HOST
+      max-parallel: 1
+
+    env:
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_GROOMER_HOST: ${{ secrets.SSH_GROOMER_HOST }}
+
+    steps:
+      # 1. Checkout Repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. Create application.yml
+      - name: Create application.yml
+        run: |
+          mkdir -p ${{ matrix.module.path }}/src/main/resources
+          echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
+
+      # 3. Create .env file
+      - name: Create .env file
+        run: |
+          echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ matrix.module.path }}/.env
+
+      # 4. Set up JDK and Build JAR
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build JAR with Gradle
+        run: |
+          ./gradlew clean :${{ matrix.module.path }}:build -x test
+
+      # 5. Verify Build Output
+      - name: Verify Build Output
+        run: ls -lh ${{ matrix.module.path }}/build/libs
+
+      # 6. Log in to Amazon ECR
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_ROOT_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_ROOT_SECRET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+      # 7. Build and Push Docker Image
+      - name: Build and Push Docker Image
+        run: |
+          set -e
+          cd ${{ matrix.module.path }}
+          
+          IMAGE_TAG="${{ matrix.module.name }}-$(date +%Y%m%d%H%M%S)"
+          
+          echo "Building Docker image..."
+          docker build --platform linux/amd64 --build-arg JAR_FILE=build/libs/${{ matrix.module.name }}-api-0.0.1-SNAPSHOT.jar -t ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG .
+          docker tag ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG ${{ secrets.ECR_REPOSITORY_URI }}:latest
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
+
+      # 8. Set up SSH
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+      # 9. Set up EC2 Host from Secrets
+      - name: Set up EC2 Host
+        run: |
+          EC2_HOST=${{ secrets[ matrix.module.ssh_host_var ] }}
+          echo "Resolved EC2_HOST: $EC2_HOST"
+          echo "EC2_HOST=$EC2_HOST" >> $GITHUB_ENV
+
+      # 10. Deploy to EC2
+      - name: Deploy to EC2
+        run: |
+          set -e
+          echo "=== Logging into EC2 ==="
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@${EC2_HOST} << 'EOF'
+          
+          # EC2에서 AWS 인증 정보 설정
+          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+          export AWS_REGION="${{ secrets.AWS_REGION }}"
+          
+           # AWS ECR에 로그인
+          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
+          
+          MODULE=${{ matrix.module.name }}
+          IMAGE_TAG=${IMAGE_TAG}
+          CONTAINER_NAME="${{matrix.module.name}}-container"
+          
+          echo "=== Cleaning up old Docker images ==="
+          # 최신 6개 이미지를 제외한 나머지 삭제
+          IMAGE_COUNT=$(docker images -q | wc -l)
+          if [ "$IMAGE_COUNT" -gt 6 ]; then
+          echo "Deleting old images, keeping the latest 6..."
+          docker images -q | tail -n +7 | xargs -r docker rmi -f
+          else
+          echo "No old images to delete. Current image count: $IMAGE_COUNT"
+          fi
+          
+          # Pull latest image
+          docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker pull failed"; exit 1; }
+          
+          echo "=== Verifying Docker images ==="
+          docker images  
+
+          echo "=== Stopping and removing existing container ==="
+          docker ps --filter "name=$CONTAINER_NAME" | grep $CONTAINER_NAME && docker stop $CONTAINER_NAME && docker rm $CONTAINER_NAME || echo "No running container to stop."
+          docker ps -a --filter "name=$CONTAINER_NAME" -q | xargs -r docker stop | xargs -r docker rm || echo "No running container to stop."
+
+          echo "=== Running new container ==="
+          docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker run failed"; exit 1; }
+
+          echo "=== Deployment completed successfully ==="

--- a/.github/workflows/dev-deploy-payment.yml
+++ b/.github/workflows/dev-deploy-payment.yml
@@ -1,0 +1,131 @@
+name: Deploy to Develop EC2
+on:
+  push:
+    branches: [ "develop-payment" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        module:
+          - name: daengle-payment
+            path: daengle-payment-api
+      max-parallel: 1
+
+    env:
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_PAYMENT_HOST: ${{ secrets.SSH_PAYMENT_HOST }}
+
+    steps:
+      # 1. Checkout Repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. Create application.yml
+      - name: Create application.yml
+        run: |
+          mkdir -p ${{ matrix.module.path }}/src/main/resources
+          echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
+
+      # 3. Create .env file
+      - name: Create .env file
+        run: |
+          echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ matrix.module.path }}/.env
+
+      # 4. Set up JDK and Build JAR
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build JAR with Gradle
+        run: |
+          ./gradlew clean :${{ matrix.module.path }}:build -x test
+
+      # 5. Verify Build Output
+      - name: Verify Build Output
+        run: ls -lh ${{ matrix.module.path }}/build/libs
+
+      # 6. Log in to Amazon ECR
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_ROOT_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_ROOT_SECRET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+      # 7. Build and Push Docker Image
+      - name: Build and Push Docker Image
+        run: |
+          set -e
+          cd ${{ matrix.module.path }}
+          
+          IMAGE_TAG="${{ matrix.module.name }}-$(date +%Y%m%d%H%M%S)"
+          
+          echo "Building Docker image..."
+          docker build --platform linux/amd64 --build-arg JAR_FILE=build/libs/${{ matrix.module.name }}-api-0.0.1-SNAPSHOT.jar -t ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG .
+          docker tag ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG ${{ secrets.ECR_REPOSITORY_URI }}:latest
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
+
+      # 8. Set up SSH
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+      # 9. Set up EC2 Host from Secrets
+      - name: Set up EC2 Host
+        run: |
+          EC2_HOST=${{ secrets[ matrix.module.ssh_host_var ] }}
+          echo "Resolved EC2_HOST: $EC2_HOST"
+          echo "EC2_HOST=$EC2_HOST" >> $GITHUB_ENV
+
+      # 10. Deploy to EC2
+      - name: Deploy to EC2
+        run: |
+          set -e
+          echo "=== Logging into EC2 ==="
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@${EC2_HOST} << 'EOF'
+          
+          # EC2에서 AWS 인증 정보 설정
+          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+          export AWS_REGION="${{ secrets.AWS_REGION }}"
+          
+           # AWS ECR에 로그인
+          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
+          
+          MODULE=${{ matrix.module.name }}
+          IMAGE_TAG=${IMAGE_TAG}
+          CONTAINER_NAME="${{matrix.module.name}}-container"
+          
+          echo "=== Cleaning up old Docker images ==="
+          # 최신 6개 이미지를 제외한 나머지 삭제
+          IMAGE_COUNT=$(docker images -q | wc -l)
+          if [ "$IMAGE_COUNT" -gt 6 ]; then
+          echo "Deleting old images, keeping the latest 6..."
+          docker images -q | tail -n +7 | xargs -r docker rmi -f
+          else
+          echo "No old images to delete. Current image count: $IMAGE_COUNT"
+          fi
+          
+          # Pull latest image
+          docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker pull failed"; exit 1; }
+          
+          echo "=== Verifying Docker images ==="
+          docker images  
+
+          echo "=== Stopping and removing existing container ==="
+          docker ps --filter "name=$CONTAINER_NAME" | grep $CONTAINER_NAME && docker stop $CONTAINER_NAME && docker rm $CONTAINER_NAME || echo "No running container to stop."
+          docker ps -a --filter "name=$CONTAINER_NAME" -q | xargs -r docker stop | xargs -r docker rm || echo "No running container to stop."
+
+          echo "=== Running new container ==="
+          docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker run failed"; exit 1; }
+
+          echo "=== Deployment completed successfully ==="

--- a/.github/workflows/dev-deploy-user.yml
+++ b/.github/workflows/dev-deploy-user.yml
@@ -1,0 +1,132 @@
+name: Deploy to Develop EC2
+on:
+  push:
+    branches: [ "develop-user" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        module:
+          - name: daengle-user
+            path: daengle-user-api
+            ssh_host_var: SSH_USER_HOST
+      max-parallel: 1
+
+    env:
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_USER_HOST: ${{ secrets.SSH_USER_HOST }}
+
+    steps:
+      # 1. Checkout Repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. Create application.yml
+      - name: Create application.yml
+        run: |
+          mkdir -p ${{ matrix.module.path }}/src/main/resources
+          echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
+
+      # 3. Create .env file
+      - name: Create .env file
+        run: |
+          echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ matrix.module.path }}/.env
+
+      # 4. Set up JDK and Build JAR
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build JAR with Gradle
+        run: |
+          ./gradlew clean :${{ matrix.module.path }}:build -x test
+
+      # 5. Verify Build Output
+      - name: Verify Build Output
+        run: ls -lh ${{ matrix.module.path }}/build/libs
+
+      # 6. Log in to Amazon ECR
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_ROOT_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_ROOT_SECRET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+      # 7. Build and Push Docker Image
+      - name: Build and Push Docker Image
+        run: |
+          set -e
+          cd ${{ matrix.module.path }}
+          
+          IMAGE_TAG="${{ matrix.module.name }}-$(date +%Y%m%d%H%M%S)"
+          
+          echo "Building Docker image..."
+          docker build --platform linux/amd64 --build-arg JAR_FILE=build/libs/${{ matrix.module.name }}-api-0.0.1-SNAPSHOT.jar -t ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG .
+          docker tag ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG ${{ secrets.ECR_REPOSITORY_URI }}:latest
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
+
+      # 8. Set up SSH
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+      # 9. Set up EC2 Host from Secrets
+      - name: Set up EC2 Host
+        run: |
+          EC2_HOST=${{ secrets[ matrix.module.ssh_host_var ] }}
+          echo "Resolved EC2_HOST: $EC2_HOST"
+          echo "EC2_HOST=$EC2_HOST" >> $GITHUB_ENV
+
+      # 10. Deploy to EC2
+      - name: Deploy to EC2
+        run: |
+          set -e
+          echo "=== Logging into EC2 ==="
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@${EC2_HOST} << 'EOF'
+          
+          # EC2에서 AWS 인증 정보 설정
+          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+          export AWS_REGION="${{ secrets.AWS_REGION }}"
+          
+           # AWS ECR에 로그인
+          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
+          
+          MODULE=${{ matrix.module.name }}
+          IMAGE_TAG=${IMAGE_TAG}
+          CONTAINER_NAME="${{matrix.module.name}}-container"
+          
+          echo "=== Cleaning up old Docker images ==="
+          # 최신 6개 이미지를 제외한 나머지 삭제
+          IMAGE_COUNT=$(docker images -q | wc -l)
+          if [ "$IMAGE_COUNT" -gt 6 ]; then
+          echo "Deleting old images, keeping the latest 6..."
+          docker images -q | tail -n +7 | xargs -r docker rmi -f
+          else
+          echo "No old images to delete. Current image count: $IMAGE_COUNT"
+          fi
+          
+          # Pull latest image
+          docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker pull failed"; exit 1; }
+          
+          echo "=== Verifying Docker images ==="
+          docker images  
+
+          echo "=== Stopping and removing existing container ==="
+          docker ps --filter "name=$CONTAINER_NAME" | grep $CONTAINER_NAME && docker stop $CONTAINER_NAME && docker rm $CONTAINER_NAME || echo "No running container to stop."
+          docker ps -a --filter "name=$CONTAINER_NAME" -q | xargs -r docker stop | xargs -r docker rm || echo "No running container to stop."
+
+          echo "=== Running new container ==="
+          docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker run failed"; exit 1; }
+
+          echo "=== Deployment completed successfully ==="

--- a/.github/workflows/dev-deploy-vet.yml
+++ b/.github/workflows/dev-deploy-vet.yml
@@ -2,8 +2,6 @@ name: Deploy to Develop EC2
 on:
   push:
     branches: [ "develop-vet" ]
-  pull_request:
-    branches: [ "develop" ] #테스트 용
 
 jobs:
   deploy:
@@ -18,6 +16,7 @@ jobs:
       max-parallel: 1
 
     env:
+      SSH_USER: ${{ secrets.SSH_USER }}
       SSH_VET_HOST: ${{ secrets.SSH_VET_HOST }}
 
 

--- a/.github/workflows/dev-deploy-vet.yml
+++ b/.github/workflows/dev-deploy-vet.yml
@@ -1,0 +1,134 @@
+name: Deploy to Develop EC2
+on:
+  push:
+    branches: [ "develop-vet" ]
+  pull_request:
+    branches: [ "develop" ] #테스트 용
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        module:
+          - name: daengle-vet
+            path: daengle-vet-api
+            ssh_host_var: SSH_VET_HOST
+      max-parallel: 1
+
+    env:
+      SSH_VET_HOST: ${{ secrets.SSH_VET_HOST }}
+
+
+    steps:
+      # 1. Checkout Repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. Create application.yml
+      - name: Create application.yml
+        run: |
+          mkdir -p ${{ matrix.module.path }}/src/main/resources
+          echo "${{ secrets.APPLICATION_YML_TEST }}" > ${{ matrix.module.path }}/src/main/resources/application.yml
+
+      # 3. Create .env file
+      - name: Create .env file
+        run: |
+          echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ matrix.module.path }}/.env
+
+      # 4. Set up JDK and Build JAR
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build JAR with Gradle
+        run: |
+          ./gradlew clean :${{ matrix.module.path }}:build -x test
+
+      # 5. Verify Build Output
+      - name: Verify Build Output
+        run: ls -lh ${{ matrix.module.path }}/build/libs
+
+      # 6. Log in to Amazon ECR
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_ROOT_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_ROOT_SECRET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+      # 7. Build and Push Docker Image
+      - name: Build and Push Docker Image
+        run: |
+          set -e
+          cd ${{ matrix.module.path }}
+          
+          IMAGE_TAG="${{ matrix.module.name }}-$(date +%Y%m%d%H%M%S)"
+          
+          echo "Building Docker image..."
+          docker build --platform linux/amd64 --build-arg JAR_FILE=build/libs/${{ matrix.module.name }}-api-0.0.1-SNAPSHOT.jar -t ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG .
+          docker tag ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG ${{ secrets.ECR_REPOSITORY_URI }}:latest
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:$IMAGE_TAG
+          docker push ${{ secrets.ECR_REPOSITORY_URI }}:latest
+
+      # 8. Set up SSH
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+      # 9. Set up EC2 Host from Secrets
+      - name: Set up EC2 Host
+        run: |
+          EC2_HOST=${{ secrets[ matrix.module.ssh_host_var ] }}
+          echo "Resolved EC2_HOST: $EC2_HOST"
+          echo "EC2_HOST=$EC2_HOST" >> $GITHUB_ENV
+
+      # 10. Deploy to EC2
+      - name: Deploy to EC2
+        run: |
+          set -e
+          echo "=== Logging into EC2 ==="
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@${EC2_HOST} << 'EOF'
+          
+          # EC2에서 AWS 인증 정보 설정
+          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+          export AWS_REGION="${{ secrets.AWS_REGION }}"
+          
+           # AWS ECR에 로그인
+          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY_URI }}
+          
+          MODULE=${{ matrix.module.name }}
+          IMAGE_TAG=${IMAGE_TAG}
+          CONTAINER_NAME="${{matrix.module.name}}-container"
+          
+          echo "=== Cleaning up old Docker images ==="
+          # 최신 6개 이미지를 제외한 나머지 삭제
+          IMAGE_COUNT=$(docker images -q | wc -l)
+          if [ "$IMAGE_COUNT" -gt 6 ]; then
+          echo "Deleting old images, keeping the latest 6..."
+          docker images -q | tail -n +7 | xargs -r docker rmi -f
+          else
+          echo "No old images to delete. Current image count: $IMAGE_COUNT"
+          fi
+          
+          # Pull latest image
+          docker pull ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker pull failed"; exit 1; }
+          
+          echo "=== Verifying Docker images ==="
+          docker images  
+
+          echo "=== Stopping and removing existing container ==="
+          docker ps --filter "name=$CONTAINER_NAME" | grep $CONTAINER_NAME && docker stop $CONTAINER_NAME && docker rm $CONTAINER_NAME || echo "No running container to stop."
+          docker ps -a --filter "name=$CONTAINER_NAME" -q | xargs -r docker stop | xargs -r docker rm || echo "No running container to stop."
+
+          echo "=== Running new container ==="
+          docker run -d --name $CONTAINER_NAME -p 8080:8080 ${{ secrets.ECR_REPOSITORY_URI }}:latest || { echo "Docker run failed"; exit 1; }
+
+          echo "=== Deployment completed successfully ==="

--- a/.github/workflows/dev-integration.yml
+++ b/.github/workflows/dev-integration.yml
@@ -5,7 +5,7 @@ name: Java CI with Gradle
 # develop 브랜치에 push, pull request가 일어 났을 경우 Actions가 실행됨
 on:
   pull_request:
-    branches: [ "NON" ]
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/dev-integration.yml
+++ b/.github/workflows/dev-integration.yml
@@ -5,7 +5,7 @@ name: Java CI with Gradle
 # develop 브랜치에 push, pull request가 일어 났을 경우 Actions가 실행됨
 on:
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "NON" ]
 
 jobs:
   build:

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/DeployCheckController.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/DeployCheckController.java
@@ -23,7 +23,7 @@ public class DeployCheckController {
 
     @GetMapping("/test")
     public String test() {
-        return "Hello Daengle World - DIFF -MULTI MODULE !!!! PAYMENT API !" +
+        return "Hello Daengle World - DIFF -MULTI MODULE !!!! PAYMENT API  2트!" +
                 " Made at: " + deploymentTime + "   CI/CD SUCCESS";
     }
 }

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/DeployCheckController.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/DeployCheckController.java
@@ -23,7 +23,7 @@ public class DeployCheckController {
 
     @GetMapping("/test")
     public String test() {
-        return "Hello Daengle World - MULTI MODULE !!!! PAYMENT API !" +
+        return "Hello Daengle World - DIFF -MULTI MODULE !!!! PAYMENT API !" +
                 " Made at: " + deploymentTime + "   CI/CD SUCCESS";
     }
 }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/DeployCheckController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/DeployCheckController.java
@@ -37,7 +37,7 @@ public class DeployCheckController {
 //        LocalDateTime now = LocalDateTime.now();
 //        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 //        String formattedDate = now.format(formatter);
-        return "Hello Daengle World - MULTI MODULE !!!! USER API !" +
+        return "Hello Daengle World - DIFF - MULTI MODULE !!!! USER API !" +
                 " Made at: " + deploymentTime + "   CI/CD SUCCESS";
     }
 

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/DeployCheckController.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/DeployCheckController.java
@@ -26,7 +26,7 @@ public class DeployCheckController {
 //        LocalDateTime now = LocalDateTime.now();
 //        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 //        String formattedDate = now.format(formatter);
-        return "Hello Daengle World - MULTI MODULE !!!! VET API !" +
+        return "Hello Daengle World - MULTI MODULE - DIFF !!!! VET API !" +
                 " Made at: " + deploymentTime + "   CI/CD SUCCESS";
     }
 }

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/DeployCheckController.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/DeployCheckController.java
@@ -26,7 +26,7 @@ public class DeployCheckController {
 //        LocalDateTime now = LocalDateTime.now();
 //        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 //        String formattedDate = now.format(formatter);
-        return "Hello Daengle World - MULTI MODULE - DIFF !!!! VET API !" +
+        return "Hello Daengle World - MULTI MODULE - DIFF !!!! VET API  3트!" +
                 " Made at: " + deploymentTime + "   CI/CD SUCCESS";
     }
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 매번 모든 모듈을 도커 이미지로 말아서 각 서버에 재배포하는 것이 굉장히 시간을 잡아먹었습니다. (8~10분)
    - 공통 라이브러리 모듈 (domain, auth 등..)이 아닌 이상 변경사항이 있는 모듈만 독립적으로 배포하는 것이 효율적입니다
    - 각 api 모듈만 독립적으로 배포하도록 워크플로우 트리거가 걸려있는 브랜치를 팠습니다.
    - 이제 공통 라이브러리 모듈의 변경이 있으면 develop에 push하여 모든 모듈이 재배포되도록 하고, 각 모듈만 독립적으로 배포하고 싶다면, develop-<도메인 명> 브랜치에 push하면 됩니다. 
    - git diff를 통해 변경사항이 있는 모듈만 추적해서 재배포 하는 워크플로우도 작성했습니다. 현재는 브랜치별로 팀원 간 책임 소재를 명확히 할 수 있다는 장점 떄문에 브랜치 별 워크플로우를 사용할 것 같지만, 추후에는 이 방식도 좋은 것 같습니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점
    - 제가 정말 여러번 테스트 (20회 이상) 했지만, 실제 운영 서버에서의 테스트도 필요합니다. 우선 개발을 몇번 하고 main 워크플로우가 잘 반영되는지 바로 테스트해보겠습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
