### PR TITLE
[fix/daengle-113] 데이터베이스 필드 추가로 인한 기존 API 이슈 해결 및 기타 수정

### DIFF
--- a/daengle-auth/src/main/java/ddog/auth/config/jwt/JwtTokenProvider.java
+++ b/daengle-auth/src/main/java/ddog/auth/config/jwt/JwtTokenProvider.java
@@ -28,7 +28,7 @@ public class JwtTokenProvider {
 
     private final Key key;
     /* accessToken 만료 시간 */
-    private final int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 3;    // 3일
+    private final int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60;    // 1시간
     /* refreshToken 만료 시간*/
     private final int REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 14;   // 14일
 

--- a/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/Groomer.java
@@ -40,6 +40,9 @@ public class Groomer {
     }
 
     public static void validateInstagramId(String instagramId) {
+        if (instagramId == null) {
+            return;
+        }
         if (instagramId.length() < 2 || instagramId.length() > 30) {
             throw new IllegalArgumentException("Instagram ID must be at least 2 characters and no more than 30 characters.");
         }

--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerKeywordPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerKeywordPersist.java
@@ -1,0 +1,9 @@
+package ddog.domain.groomer.port;
+
+import ddog.domain.groomer.GroomerKeyword;
+
+public interface GroomerKeywordPersist {
+
+    GroomerKeyword save(GroomerKeyword keyword);
+
+}

--- a/daengle-domain/src/main/java/ddog/domain/vet/port/VetKeywordPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/vet/port/VetKeywordPersist.java
@@ -1,0 +1,8 @@
+package ddog.domain.vet.port;
+
+import ddog.domain.vet.VetKeyword;
+
+public interface VetKeywordPersist {
+
+    VetKeyword save(VetKeyword vetKeyword);
+}

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/AccountService.java
@@ -15,6 +15,8 @@ import ddog.domain.payment.port.PaymentPersist;
 import ddog.domain.payment.port.ReservationPersist;
 import ddog.domain.shop.BeautyShop;
 import ddog.domain.shop.port.BeautyShopPersist;
+import ddog.groomer.application.exception.account.AccountException;
+import ddog.groomer.application.exception.account.AccountExceptionType;
 import ddog.groomer.application.exception.account.GroomerException;
 import ddog.groomer.application.exception.account.GroomerExceptionType;
 import ddog.groomer.application.mapper.BeautyShopMapper;
@@ -57,8 +59,10 @@ public class AccountService {
 
     @Transactional
     public SignUpResp signUp(SignUpReq request, HttpServletResponse response) {
-
         validateSignUpReqDataFormat(request);
+
+        accountPersist.findAccountByEmailAndRole(request.getEmail(), Role.VET)
+                .orElseThrow(() -> new AccountException(AccountExceptionType.DUPLICATE_ACCOUNT));
 
         Account newAccount = Account.create(request.getEmail(), Role.GROOMER);
         Account savedAccount = accountPersist.save(newAccount);

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/account/AccountExceptionType.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/exception/account/AccountExceptionType.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum AccountExceptionType {
     INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
     ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
-    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
+    DUPLICATE_ACCOUNT(HttpStatus.BAD_REQUEST, 400, "이미 가입된 계정");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/application/mapper/GroomerMapper.java
@@ -2,10 +2,11 @@ package ddog.groomer.application.mapper;
 
 import ddog.domain.groomer.Groomer;
 import ddog.domain.groomer.License;
-import ddog.groomer.presentation.account.dto.UpdateInfoReq;
 import ddog.groomer.presentation.account.dto.ProfileInfo;
 import ddog.groomer.presentation.account.dto.SignUpReq;
+import ddog.groomer.presentation.account.dto.UpdateInfoReq;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class GroomerMapper {
@@ -14,16 +15,20 @@ public class GroomerMapper {
         return Groomer.builder()
                 .accountId(accountId)
                 .daengleMeter(50)
-                .imageUrl("")
+                .introduction(null)
                 .name(request.getName())
                 .phoneNumber(request.getPhoneNumber())
+                .imageUrl("")
                 .email(request.getEmail())
                 .address(request.getAddress())
                 .detailAddress(request.getDetailAddress())
                 .shopId(shopId)
                 .shopName(request.getShopName())
+                .introduction(null)
                 .businessLicenses(request.getBusinessLicenses())
                 .licenses(licenses)
+                .badges(null)
+                .keywords(new ArrayList<>())
                 .build();
     }
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerKeywordRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomerKeywordRepository.java
@@ -1,0 +1,21 @@
+package ddog.persistence.mysql.adapter;
+
+import ddog.domain.groomer.GroomerKeyword;
+import ddog.domain.groomer.port.GroomerKeywordPersist;
+import ddog.persistence.mysql.jpa.entity.GroomerKeywordJpaEntity;
+import ddog.persistence.mysql.jpa.repository.GroomerKeywordJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GroomerKeywordRepository implements GroomerKeywordPersist {
+
+    private final GroomerKeywordJpaRepository groomerKeywordJpaRepository;
+
+    @Override
+    public GroomerKeyword save(GroomerKeyword keyword) {
+        return groomerKeywordJpaRepository.save(GroomerKeywordJpaEntity.from(keyword))
+                .toModel();
+    }
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetKeywordRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/VetKeywordRepository.java
@@ -1,0 +1,21 @@
+package ddog.persistence.mysql.adapter;
+
+import ddog.domain.vet.VetKeyword;
+import ddog.domain.vet.port.VetKeywordPersist;
+import ddog.persistence.mysql.jpa.entity.VetKeywordJpaEntity;
+import ddog.persistence.mysql.jpa.repository.VetKeywordJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class VetKeywordRepository implements VetKeywordPersist {
+
+    private final VetKeywordJpaRepository vetKeywordJpaRepository;
+
+    @Override
+    public VetKeyword save(VetKeyword vetKeyword) {
+        return vetKeywordJpaRepository.save(VetKeywordJpaEntity.from(vetKeyword))
+                .toModel();
+    }
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/BeautyShopJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/BeautyShopJpaEntity.java
@@ -42,13 +42,12 @@ public class BeautyShopJpaEntity {
     @ElementCollection // 휴무일 리스트
     @CollectionTable(name = "shop_closed_days", joinColumns = @JoinColumn(name = "shop_id"))
     @Column(name = "day")
+    @Enumerated(EnumType.STRING)
     private List<Day> closedDays;
-
 
     private String introduction;
 
-
-    public static BeautyShopJpaEntity from (BeautyShop beautyShop) {
+    public static BeautyShopJpaEntity from(BeautyShop beautyShop) {
         return BeautyShopJpaEntity.builder()
                 .shopId(beautyShop.getShopId())
                 .shopName(beautyShop.getShopName())

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/CareReviewJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/CareReviewJpaEntity.java
@@ -37,8 +37,8 @@ public class CareReviewJpaEntity {
 
     @ElementCollection // 키워드 리스트
     @CollectionTable(name = "care_review_keyword_list", joinColumns = @JoinColumn(name = "care_review_id"))
-    @Enumerated(EnumType.STRING)
     @Column(name = "keyword_list")
+    @Enumerated(EnumType.STRING)
     private List<CareKeyword> careKeywordList;
 
     public static CareReviewJpaEntity from (CareReview careReview) {

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ChatRoomJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/ChatRoomJpaEntity.java
@@ -20,6 +20,7 @@ public class ChatRoomJpaEntity {
     private Long chatRoomId;
     private Long userId;
     private Long partnerId;
+
     @Enumerated(value = EnumType.STRING)
     private PartnerType partnerType;
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/PaymentJpaEntity.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/entity/PaymentJpaEntity.java
@@ -35,18 +35,6 @@ public class PaymentJpaEntity {
     @Column(nullable = false, unique = true)
     private String idempotencyKey; // 멱등성 키 필드
 
-    public Payment toModel() {
-        return Payment.builder()
-                .paymentId(this.paymentId)
-                .payerId(this.payerId)
-                .price(this.price)
-                .status(this.status)
-                .paymentDate(this.paymentDate)
-                .paymentUid(this.paymentUid)
-                .idempotencyKey(this.idempotencyKey)
-                .build();
-    }
-
     public static PaymentJpaEntity from(Payment payment) {
         return PaymentJpaEntity.builder()
                 .paymentId(payment.getPaymentId())
@@ -56,6 +44,18 @@ public class PaymentJpaEntity {
                 .paymentDate(payment.getPaymentDate())
                 .paymentUid(payment.getPaymentUid())
                 .idempotencyKey(payment.getIdempotencyKey())
+                .build();
+    }
+
+    public Payment toModel() {
+        return Payment.builder()
+                .paymentId(this.paymentId)
+                .payerId(this.payerId)
+                .price(this.price)
+                .status(this.status)
+                .paymentDate(this.paymentDate)
+                .paymentUid(this.paymentUid)
+                .idempotencyKey(this.idempotencyKey)
                 .build();
     }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomerKeywordJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomerKeywordJpaRepository.java
@@ -1,0 +1,10 @@
+package ddog.persistence.mysql.jpa.repository;
+
+import ddog.persistence.mysql.jpa.entity.GroomerKeywordJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroomerKeywordJpaRepository extends JpaRepository<GroomerKeywordJpaEntity, Long> {
+
+    GroomerKeywordJpaEntity save(GroomerKeywordJpaEntity groomerKeyword);
+
+}

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/VetKeywordJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/VetKeywordJpaRepository.java
@@ -1,0 +1,10 @@
+package ddog.persistence.mysql.jpa.repository;
+
+import ddog.persistence.mysql.jpa.entity.VetKeywordJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VetKeywordJpaRepository extends JpaRepository<VetKeywordJpaEntity, Long> {
+
+    VetKeywordJpaEntity save(VetKeywordJpaEntity vetKeyword);
+
+}

--- a/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/CareReviewService.java
@@ -1,39 +1,36 @@
 package ddog.user.application;
 
 import ddog.domain.filtering.BanWordValidator;
-import ddog.domain.groomer.Groomer;
-import ddog.domain.groomer.GroomerKeyword;
-import ddog.domain.groomer.enums.GroomingBadge;
-import ddog.domain.groomer.enums.GroomingKeyword;
 import ddog.domain.payment.Reservation;
 import ddog.domain.payment.enums.ServiceType;
+import ddog.domain.payment.port.ReservationPersist;
 import ddog.domain.review.CareReview;
+import ddog.domain.review.port.CareReviewPersist;
+import ddog.domain.user.User;
+import ddog.domain.user.port.UserPersist;
+import ddog.domain.vet.Vet;
 import ddog.domain.vet.VetDaengleMeter;
 import ddog.domain.vet.VetKeyword;
 import ddog.domain.vet.enums.CareBadge;
 import ddog.domain.vet.enums.CareKeyword;
 import ddog.domain.vet.port.VetDaengleMeterPersist;
-import ddog.user.application.exception.account.VetException;
-import ddog.user.application.exception.account.VetExceptionType;
-import ddog.user.application.mapper.CareReviewMapper;
-import ddog.user.presentation.review.dto.request.PostGroomingReviewInfo;
-import ddog.user.presentation.review.dto.response.CareReviewListResp;
-import ddog.user.presentation.review.dto.request.UpdateCareReviewInfo;
-import ddog.user.presentation.review.dto.request.PostCareReviewInfo;
-import ddog.domain.user.User;
-import ddog.domain.vet.Vet;
-import ddog.domain.review.port.CareReviewPersist;
-import ddog.domain.payment.port.ReservationPersist;
-import ddog.domain.user.port.UserPersist;
+import ddog.domain.vet.port.VetKeywordPersist;
 import ddog.domain.vet.port.VetPersist;
-import ddog.user.application.exception.*;
+import ddog.user.application.exception.ReviewException;
+import ddog.user.application.exception.ReviewExceptionType;
 import ddog.user.application.exception.account.UserException;
 import ddog.user.application.exception.account.UserExceptionType;
+import ddog.user.application.exception.account.VetException;
+import ddog.user.application.exception.account.VetExceptionType;
 import ddog.user.application.exception.estimate.ReservationException;
 import ddog.user.application.exception.estimate.ReservationExceptionType;
+import ddog.user.application.mapper.CareReviewMapper;
+import ddog.user.presentation.review.dto.request.PostCareReviewInfo;
+import ddog.user.presentation.review.dto.request.UpdateCareReviewInfo;
 import ddog.user.presentation.review.dto.response.CareReviewDetailResp;
-import ddog.user.presentation.review.dto.response.ReviewResp;
+import ddog.user.presentation.review.dto.response.CareReviewListResp;
 import ddog.user.presentation.review.dto.response.CareReviewSummaryResp;
+import ddog.user.presentation.review.dto.response.ReviewResp;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -42,6 +39,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -51,6 +50,7 @@ public class CareReviewService {
 
     private final VetPersist vetPersist;
     private final UserPersist userPersist;
+    private final VetKeywordPersist vetKeywordPersist;
     private final CareReviewPersist careReviewPersist;
     private final ReservationPersist reservationPersist;
     private final VetDaengleMeterPersist vetDaengleMeterPersist;
@@ -87,15 +87,17 @@ public class CareReviewService {
         Vet savedVet = vetPersist.findByVetId(reservation.getRecipientId())
                 .orElseThrow(() -> new VetException(VetExceptionType.VET_NOT_FOUND));
 
-        if(careReviewPersist.findByReservationId(postCareReviewInfo.getReservationId())
+        if (careReviewPersist.findByReservationId(postCareReviewInfo.getReservationId())
                 .isPresent()) throw new ReviewException(ReviewExceptionType.REVIEW_HAS_WRITTEN);
 
-        if(reservation.getServiceType() != ServiceType.CARE) throw new ReviewException(ReviewExceptionType.REVIEW_INVALID_SERVICE_TYPE);
+        if (reservation.getServiceType() != ServiceType.CARE)
+            throw new ReviewException(ReviewExceptionType.REVIEW_INVALID_SERVICE_TYPE);
 
         validatePostCareReviewInfoDataFormat(postCareReviewInfo);
 
         String includedBanWord = banWordValidator.findBanWords(postCareReviewInfo.getContent());
-        if(includedBanWord != null) throw new ReviewException(ReviewExceptionType.REVIEW_CONTENT_CONTAIN_BAN_WORD, includedBanWord);
+        if (includedBanWord != null)
+            throw new ReviewException(ReviewExceptionType.REVIEW_CONTENT_CONTAIN_BAN_WORD, includedBanWord);
 
         CareReview careReviewToSave = CareReviewMapper.createBy(reservation, postCareReviewInfo);
         CareReview savedCareReview = careReviewPersist.save(careReviewToSave);
@@ -123,17 +125,17 @@ public class CareReviewService {
 
     private void processKeywords(PostCareReviewInfo postCareReviewInfo, Vet vet) {
 
-        List<VetKeyword> vetKeywords = vet.getKeywords();
-        List<CareBadge> badges = vet.getBadges();
+        List<VetKeyword> vetKeywords = new ArrayList<>(vet.getKeywords());
+        List<CareBadge> badges = new ArrayList<>(vet.getBadges());
 
         List<CareKeyword> postKeywords = postCareReviewInfo.getCareKeywordList();
-
         for (CareKeyword postKeyword : postKeywords) {
             boolean isAdded = false;
 
             for (VetKeyword vetKeyword : vetKeywords) {
                 if (postKeyword.toString().equals(vetKeyword.getKeyword())) {
                     vetKeyword.increaseCount();
+                    vetKeywordPersist.save(vetKeyword);
 
                     if (vetKeyword.isAvailableRegisterBadge()) {
                         if (postKeyword.getBadge() != null) {
@@ -149,9 +151,9 @@ public class CareReviewService {
             }
 
             VetKeyword newKeyword = VetKeyword.createNewKeyword(vet.getAccountId(), postKeyword.toString());
-            vetKeywords.add(newKeyword);
+            VetKeyword savedKeyword = vetKeywordPersist.save(newKeyword);
+            vetKeywords.add(savedKeyword);
         }
-
         vet.updateKeywords(vetKeywords);
         vet.updateBadges(badges);
     }
@@ -167,7 +169,8 @@ public class CareReviewService {
         validateModifyCareReviewInfoDataFormat(updateCareReviewInfo);
 
         String includedBanWord = banWordValidator.findBanWords(updateCareReviewInfo.getContent());
-        if(includedBanWord != null) throw new ReviewException(ReviewExceptionType.REVIEW_CONTENT_CONTAIN_BAN_WORD, includedBanWord);
+        if (includedBanWord != null)
+            throw new ReviewException(ReviewExceptionType.REVIEW_CONTENT_CONTAIN_BAN_WORD, includedBanWord);
 
         CareReview modifiedReview = CareReviewMapper.modifyBy(savedCareReview, updateCareReviewInfo);
         CareReview updatedCareReview = careReviewPersist.save(modifiedReview);

--- a/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/GroomingReviewService.java
@@ -7,6 +7,7 @@ import ddog.domain.groomer.GroomerKeyword;
 import ddog.domain.groomer.enums.GroomingBadge;
 import ddog.domain.groomer.enums.GroomingKeyword;
 import ddog.domain.groomer.port.GroomerDaengleMeterPersist;
+import ddog.domain.groomer.port.GroomerKeywordPersist;
 import ddog.domain.groomer.port.GroomerPersist;
 import ddog.domain.payment.Reservation;
 import ddog.domain.payment.enums.ServiceType;
@@ -38,6 +39,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -47,6 +49,7 @@ public class GroomingReviewService {
 
     private final UserPersist userPersist;
     private final GroomerPersist groomerPersist;
+    private final GroomerKeywordPersist groomerKeywordPersist;
     private final ReservationPersist reservationPersist;
     private final GroomingReviewPersist groomingReviewPersist;
     private final GroomerDaengleMeterPersist groomerDaengleMeterPersist;
@@ -121,8 +124,8 @@ public class GroomingReviewService {
 
     private void processKeywords(PostGroomingReviewInfo postGroomingReviewInfo, Groomer groomer) {
 
-        List<GroomerKeyword> groomerKeywords = groomer.getKeywords();
-        List<GroomingBadge> badges = groomer.getBadges();
+        List<GroomerKeyword> groomerKeywords = new ArrayList<>(groomer.getKeywords());
+        List<GroomingBadge> badges = new ArrayList<>(groomer.getBadges());
 
         List<GroomingKeyword> postKeywords = postGroomingReviewInfo.getGroomingKeywordList();
 
@@ -147,7 +150,8 @@ public class GroomingReviewService {
             }
             
             GroomerKeyword newKeyword = GroomerKeyword.createNewKeyword(groomer.getAccountId(), postKeyword.toString());
-            groomerKeywords.add(newKeyword);
+            GroomerKeyword savedKeyword = groomerKeywordPersist.save(newKeyword);
+            groomerKeywords.add(savedKeyword);
         }
 
         groomer.updateKeywords(groomerKeywords);

--- a/daengle-user-api/src/main/java/ddog/user/application/exception/account/AccountExceptionType.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/exception/account/AccountExceptionType.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum AccountExceptionType {
     INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
     ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
-    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
+    DUPLICATE_ACCOUNT(HttpStatus.BAD_REQUEST, 400, "이미 가입된 계정");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/daengle-vet-api/src/main/java/ddog/vet/application/exception/account/AccountExceptionType.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/exception/account/AccountExceptionType.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum AccountExceptionType {
     INVALID_REQUEST_DATA_FORMAT(HttpStatus.BAD_REQUEST, 400, "데이터 형식 오류"),
     ACCOUNT_EXCEPTION_TYPE(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
-    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),;
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "유저를 찾을 수 없음"),
+    DUPLICATE_ACCOUNT(HttpStatus.BAD_REQUEST, 400, "이미 가입된 계정");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetMapper.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/application/mapper/VetMapper.java
@@ -6,22 +6,28 @@ import ddog.vet.presentation.account.dto.ProfileInfo;
 import ddog.vet.presentation.account.dto.SignUpReq;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
 
 public class VetMapper {
 
     public static Vet create(Long accountId, SignUpReq request) {
         return Vet.builder()
                 .accountId(accountId)
+                .email(request.getEmail())
                 .daengleMeter(50)
                 .name(request.getName())
                 .imageUrl("")
+                .imageUrlList(null)
                 .address(request.getAddress())
                 .detailAddress(request.getDetailAddress())
                 .phoneNumber(request.getPhoneNumber())
-                .licenses(request.getLicenses())
-                .email(request.getEmail())
+                .introduction(null)
                 .startTime(LocalTime.of(0, 0))
                 .endTime(LocalTime.of(23, 59))
+                .closedDays(null)
+                .licenses(request.getLicenses())
+                .badges(null)
+                .keywords(new ArrayList<>())
                 .build();
     }
 

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/account/AccountController.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/account/AccountController.java
@@ -34,8 +34,8 @@ public class AccountController {
     }
 
     @PatchMapping("/info")
-    public CommonResponseEntity<AccountResp> modifyInfo(@RequestBody UpdateInfo request, PayloadDto payloadDto) {
-        return success(accountService.modifyInfo(request, payloadDto.getAccountId()));
+    public CommonResponseEntity<AccountResp> updateInfo(@RequestBody UpdateInfo request, PayloadDto payloadDto) {
+        return success(accountService.updateInfo(request, payloadDto.getAccountId()));
     }
 
     @GetMapping("/withdraw-info")


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - JWT accessToken 만료시간 3일 -> 1시간으로 변경
    - 미용사 인스타그램 ID `null` 값 허용하도록 검증 추가
    - 미용사/병원 회원가입시 Keyword 객체 null -> 빈 리스트로 초기화
    - 사용자/미용사/병원 회원가입시 이미 존재하는 Account 데이터가 있는지 검증로직 추가
    - Groomer/VetKeyword 에 해당하는 Persist, Repository, JpaRepository 추가
    - 계정 관련 서비스 네이밍 일부 수정
    - 엔티티 객체 중 enum 객체를 활용하는 곳 중 @Enumerated 없는 부분 추가

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - `Keyword` 및 `Badge` 테이블을 추가하면서 이와 관련된 로직들에 대한 충돌이 발생하고 있습니다. 계속해서 문제가 발견되면 해당 테이블에 대해 집중적으로 코드 리팩토링 진행하겠습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
