### PR TITLE
[feat/daengle-116] 결제시스템, 타임아웃 설정

### DIFF
--- a/daengle-payment-api/build.gradle
+++ b/daengle-payment-api/build.gradle
@@ -9,36 +9,46 @@ jar {
 repositories {
     mavenCentral()
 
-    //IamPort
-    maven {url 'https://jitpack.io'}
+    // IamPort
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
-    implementation(project(':daengle-domain'))
-    implementation(project(':daengle-auth'))
-    implementation(project(':daengle-notification'))
+    // 내부 모듈 의존성
+    implementation project(':daengle-domain')
+    implementation project(':daengle-auth')
+    implementation project(':daengle-notification')
 
+    // Spring Boot 의존성
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework:spring-tx'
-    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
     implementation 'org.springframework.data:spring-data-commons'
 
-    // IamPort //
-    implementation group: 'com.github.iamport', name: 'iamport-rest-client-java', version: '0.2.22'
-    implementation group: 'com.squareup.retrofit2', name: 'adapter-rxjava2', version: '2.9.0'
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.3'
-    implementation group: 'com.squareup.retrofit2', name: 'converter-gson', version: '2.3.0'
+    // 환경 변수 관리
+    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 
-    // security
+    // IamPort
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.22'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
+
+    // Hibernate (Jakarta 지원)
+    implementation 'org.hibernate.orm:hibernate-core:6.2.15.Final'
+
+    // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    // jwt
+    // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // 테스트
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 test {

--- a/daengle-payment-api/src/main/java/ddog/payment/application/exception/PaymentExceptionType.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/application/exception/PaymentExceptionType.java
@@ -12,9 +12,11 @@ public enum PaymentExceptionType {
     PAYMENT_ALREADY_PROCESSED(HttpStatus.CONFLICT, 409, "중복된 결제 검증 요청"),
     PAYMENT_PG_INTEGRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "결제 정보 조회 중 에러 발생"),
     PAYMENT_PG_INCOMPLETE(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "미완료된 결제건"),
-    PAYMENT_ALREADY_COMPLETED(HttpStatus.NOT_FOUND, 5003, "이미 결제된 결제건"),
-    PAYMENT_PG_AMOUNT_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, 5004, "결제 금액 불일치"),
-    PAYMENT_CANCEL_BATCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5005, "예약 취소 배치 처리 중 에러 발생");
+    PAYMENT_PG_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, 5003, "PG사 API 연결 타임 아웃"),
+    PAYMENT_ALREADY_COMPLETED(HttpStatus.NOT_FOUND, 5004, "이미 결제된 결제건"),
+    PAYMENT_PG_AMOUNT_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, 5005, "결제 금액 불일치"),
+    PAYMENT_CANCEL_BATCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5006, "예약 취소 배치 처리 중 에러 발생");
+
 
     private final HttpStatus httpStatus;
     private final Integer code;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - https://docs.tosspayments.com/resources/glossary/timeout

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 현재 결제 시스템은 외부 API(PortOne)에 의존하기 때문에, 장애 대응에 취약합니다.
    - 만약 포트원 서버에 장애가 생겨 연결이나 응답이 지연되었다면, 저희 결제 API 서버까지 장애가 전파되고 웹서버를 무한로딩시키게 됩니다.
    - 때문에 Connection timeout / Read timeout 설정이 필요합니다.
    
    - CompletableFuture를 활용하여 외부 API와 연동하는 메서드를 비동기로 처리하고, 이 비동기 작업이 일정 시간 이상 응답을 주지 않는다면 작업을 중단시킵니다. 
    - 웹서버에게는 PG사 연결 오류 코드를 응답합니다.
    - 임의로 비동기 작업에 장애를 일으켜 타임 아웃 패턴이 잘 구현되었는지 확인했습니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 하지만 PG사에서 해당 유저의 잔액을 계좌에서 인출시킨 뒤 서버에 장애가 생겼다면 실제 결제는 처리되었지만 웹서버는 유저에게 결제되지않았다는 화면을 보여주게됩니다. 
    - 이에 대응하기 위해서 타임아웃이 발생했을 때, 이 결제 검증 요청 메타데이터를 작업 큐에 집어 넣고 스케줄링을 통해 주기적으로 PG사 연결을 시도하여 이 큐에 담겨 있던 결제 시도들이 실제 처리되지는 않았는지 확인하고 처리되었다면 환불 요청하는 기능을 구현해야합니다.
    - 이 작업 큐를 어떤 자료구조로 처리할지는 고민해보겠습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
