### PR TITLE
[feat/daengle-88] SQL 튜닝을 통한 MySQL 조회 성능 최적화

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/estimate/dto/PetInfos.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/dto/PetInfos.java
@@ -1,0 +1,22 @@
+package ddog.domain.estimate.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PetInfos {
+
+    private List<Content> pets;
+
+    @Builder
+    @Getter
+    public static class Content {
+        private Long estimateId;
+        private Long petId;
+        private String imageUrl;
+        private String name;
+    }
+}

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
@@ -3,6 +3,7 @@ package ddog.domain.estimate.port;
 import ddog.domain.estimate.CareEstimate;
 import ddog.domain.estimate.EstimateStatus;
 import ddog.domain.estimate.Proposal;
+import ddog.domain.estimate.dto.PetInfos;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -20,6 +21,8 @@ public interface CareEstimatePersist {
     Page<CareEstimate> findByPetIdAndStatusAndProposal(Long petId, EstimateStatus status, Proposal proposal, Pageable pageable);
 
     Optional<CareEstimate> findByEstimateStatusAndProposalAndPetId(EstimateStatus estimateStatus, Proposal proposal, Long petId);
+
+    List<PetInfos.Content> findByStatusAndProposalAndUserId(EstimateStatus status, Proposal proposal, Long userId);
 
     Page<CareEstimate> findByStatusAndProposalAndAddress(EstimateStatus estimateStatus, Proposal proposal, String address, Pageable pageable);
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
@@ -3,9 +3,11 @@ package ddog.persistence.mysql.adapter;
 import ddog.domain.estimate.CareEstimate;
 import ddog.domain.estimate.EstimateStatus;
 import ddog.domain.estimate.Proposal;
+import ddog.domain.estimate.dto.PetInfos;
 import ddog.domain.estimate.port.CareEstimatePersist;
 import ddog.persistence.mysql.jpa.entity.CareEstimateJpaEntity;
 import ddog.persistence.mysql.jpa.repository.CareEstimateJpaRepository;
+import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +17,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -44,6 +47,20 @@ public class CareEstimateRepository implements CareEstimatePersist {
     public Optional<CareEstimate> findByEstimateStatusAndProposalAndPetId(EstimateStatus estimateStatus, Proposal proposal, Long petId) {
         return careEstimateJpaRepository.findTopByStatusAndProposalAndPetId(estimateStatus, proposal, petId)
                 .map(CareEstimateJpaEntity::toModel);
+    }
+
+    @Override
+    public List<PetInfos.Content> findByStatusAndProposalAndUserId(EstimateStatus status, Proposal proposal, Long userId) {
+        List<Tuple> results = careEstimateJpaRepository.findByStatusAndProposalAndUserId(status, proposal, userId);
+
+        return results.stream()
+                .map(tuple -> PetInfos.Content.builder()
+                        .estimateId(tuple.get("estimateId", Long.class))
+                        .petId(tuple.get("petId", Long.class))
+                        .imageUrl(tuple.get("imageUrl", String.class))
+                        .name(tuple.get("name", String.class))
+                        .build())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
@@ -2,7 +2,9 @@ package ddog.persistence.mysql.jpa.repository;
 
 import ddog.domain.estimate.EstimateStatus;
 import ddog.domain.estimate.Proposal;
+import ddog.domain.estimate.dto.PetInfos;
 import ddog.persistence.mysql.jpa.entity.CareEstimateJpaEntity;
+import jakarta.persistence.Tuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,6 +34,11 @@ public interface CareEstimateJpaRepository extends JpaRepository<CareEstimateJpa
     void updateStatusByParentId(@Param("status") EstimateStatus status, @Param("parentId") Long parentId);
 
     Optional<CareEstimateJpaEntity> findTopByStatusAndProposalAndPetId(EstimateStatus status, Proposal proposal, Long petId);
+
+    @Query("SELECT c.estimateId as estimateId, c.petId as petId, p.imageUrl as imageUrl, p.name as name " +
+            "FROM CareEstimates c JOIN Pets p ON c.petId = p.petId " +
+            "WHERE c.userId = :userId AND c.status = :status AND c.proposal = :proposal")
+    List<Tuple> findByStatusAndProposalAndUserId(EstimateStatus status, Proposal proposal, Long userId);
 
     Page<CareEstimateJpaEntity> findByPetIdAndStatusAndProposal(Long petId, EstimateStatus status, Proposal proposal, Pageable pageable);
 

--- a/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
@@ -148,7 +148,31 @@ public class EstimateService {
                 .build();
     }
 
-    public PetInfos findGeneralCarePets(Long accountId) {
+    /* SQL 튜닝 전 조회 */
+    @Transactional(readOnly = true)
+    public EstimateInfo.Pet findGeneralCarePets(Long accountId) {
+        User user = userPersist.findByAccountId(accountId)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        List<Pet> pets = user.getPets();
+        List<EstimateInfo.Pet.Content> contents = new ArrayList<>();
+        for (Pet pet : pets) {
+            careEstimatePersist.findByEstimateStatusAndProposalAndPetId(EstimateStatus.NEW, Proposal.GENERAL, pet.getPetId())
+                    .ifPresent(estimate -> contents.add(EstimateInfo.Pet.Content.builder()
+                            .estimateId(estimate.getEstimateId())
+                            .petId(pet.getPetId())
+                            .imageUrl(pet.getImageUrl())
+                            .name(pet.getName())
+                            .build()));
+        }
+        return EstimateInfo.Pet.builder()
+                .pets(contents)
+                .build();
+    }
+
+    /* SQL 튜닝 후 조회 */
+    @Transactional(readOnly = true)
+    public PetInfos findTuningGeneralCarePets(Long accountId) {
         userPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
 

--- a/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/EstimateService.java
@@ -4,6 +4,7 @@ import ddog.domain.estimate.CareEstimate;
 import ddog.domain.estimate.EstimateStatus;
 import ddog.domain.estimate.GroomingEstimate;
 import ddog.domain.estimate.Proposal;
+import ddog.domain.estimate.dto.PetInfos;
 import ddog.domain.estimate.port.CareEstimatePersist;
 import ddog.domain.estimate.port.GroomingEstimatePersist;
 import ddog.domain.groomer.Groomer;
@@ -141,27 +142,19 @@ public class EstimateService {
                             .name(pet.getName())
                             .build()));
         }
+
         return EstimateInfo.Pet.builder()
                 .pets(contents)
                 .build();
     }
 
-    public EstimateInfo.Pet findGeneralCarePets(Long accountId) {
-        User user = userPersist.findByAccountId(accountId)
+    public PetInfos findGeneralCarePets(Long accountId) {
+        userPersist.findByAccountId(accountId)
                 .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
 
-        List<Pet> pets = user.getPets();
-        List<EstimateInfo.Pet.Content> contents = new ArrayList<>();
-        for (Pet pet : pets) {
-            careEstimatePersist.findByEstimateStatusAndProposalAndPetId(EstimateStatus.NEW, Proposal.GENERAL, pet.getPetId())
-                    .ifPresent(estimate -> contents.add(EstimateInfo.Pet.Content.builder()
-                            .estimateId(estimate.getEstimateId())
-                            .petId(pet.getPetId())
-                            .imageUrl(pet.getImageUrl())
-                            .name(pet.getName())
-                            .build()));
-        }
-        return EstimateInfo.Pet.builder()
+        List<PetInfos.Content> contents = careEstimatePersist.findByStatusAndProposalAndUserId(EstimateStatus.NEW, Proposal.GENERAL, accountId);
+
+        return PetInfos.builder()
                 .pets(contents)
                 .build();
     }

--- a/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/estimate/EstimateController.java
@@ -2,6 +2,7 @@ package ddog.user.presentation.estimate;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
+import ddog.domain.estimate.dto.PetInfos;
 import ddog.user.application.EstimateService;
 import ddog.user.presentation.estimate.dto.*;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,12 @@ public class EstimateController {
     @GetMapping("/general/care/pets")
     public CommonResponseEntity<EstimateInfo.Pet> findGeneralCarePets(PayloadDto payloadDto) {
         return success(estimateService.findGeneralCarePets(payloadDto.getAccountId()));
+    }
+
+    /* (일반) 대기 진료 견적서 페이지 반려동물 정보 반환 SQL 튜닝 버젼 */
+    @GetMapping("/general/care/pets/tuning")
+    public CommonResponseEntity<PetInfos> findTuningGeneralCarePets(PayloadDto payloadDto) {
+        return success(estimateService.findTuningGeneralCarePets(payloadDto.getAccountId()));
     }
 
     /* (일반) 대기 미용 견적서 리스트 조회 */


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 사용자측 일반 진료 대기 견적서 반려동물 정보 반환 API 쿼리 튜닝 (인덱스 추가)
    - 기존 반복 쿼리를 수행했던 방식에서 JOIN 연산을 통해 한 번의 쿼리 요청으로 원하는 데이터 조회
    - 기존 조회 API와 최적화된 API 와의 성능 비교

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

현재 저희 서비스 DB에는 데이터가 많아야 1,000개 이하이기 때문에 **비효율적으로 작성된 쿼리**로도 원하는 데이터를 빠른 속도로 가져올 수 있습니다.

하지만, 서비스를 운영하고 데이터의 양이 100만 개 혹은 그 이상으로 데이터가 쌓이게된다면, 현저히 느린 조회 속도로 소비자에게 불편함을 제공할 것이고 이는 **소비자의 이탈**까지 이어지게 될 것입니다.

이러한 불상사를 방지하고자 추가적인 시스템을 구축하기 전 즉각적인 성능 향상을 가져올 수 있는 **SQL 튜닝**을 적용해봤습니다.

`100만`개의 더미 데이터를 넣어준 뒤, 사용자들이 많이 요청하고 비효율적으로 `SELECT` 쿼리를 요청하는 **일반 진료 대기 견적서 반려동물 정보 반환 API**에 대해 최적화를 진행하였고 개선 전과 후를 비교해봤습니다.

## 기존 조회 API
해당 API 에서 원하는 데이터를 가져오기 위한 쿼리문 입니다.

```sql
SELECT * FROM care_estimates WHERE status = :status AND proposal = :proposal AND pet_id = :pet_id;
```

![1](https://github.com/user-attachments/assets/393fe825-2968-4b93-9d7f-4f469054f487)
매우 간단한 쿼리문이지만 풀 테이블 스캔을 하기 때문에
```sql
-> Filter: ((care_estimates.pet_id = 31627) and (care_estimates.proposal = 'GENERAL') and (care_estimates.`status` = 'NEW'))  (cost=106672 rows=12332) (actual time=94.8..646 rows=1 loops=1)
    -> Table scan on care_estimates  (cost=106672 rows=986595) (actual time=0.312..618 rows=1e+6 loops=1)
```
![image](https://github.com/user-attachments/assets/56ae01ad-43a7-4c94-8e06-f683c840b180)
하나의 데이터를 찾아서 가져오는데 약 `600ms` 의 조회 성능을 가집니다. 만약, 5 개의 데이터를 요청한다면 `3000ms = 3초`의 시간이나 걸리게 됩니다.

## 인덱스를 활용한 SQL 튜닝
이런 문제를 해결하기 위해 인덱스를 활용하기로 결정하고, `WHERE` 조건문에 들어있는 데이터들 중 **데이터 중복도**가 낮은 `pet_id` 를 인덱스 컬럼으로 활용하기로 결정했습니다.
```sql
CREATE INDEX pet_id ON care_estimates(pet_id);
```

```sql
-> Filter: ((care_estimates.proposal = 'GENERAL') and (care_estimates.`status` = 'NEW'))  (cost=4.46 rows=0.875) (actual time=0.0544..0.0578 rows=1 loops=1)
    -> Index lookup on care_estimates using pet_id (pet_id=31627)  (cost=4.46 rows=7) (actual time=0.0486..0.0529 rows=7 loops=1)
```
인덱스 생성후 조회시 이전과는 달리 풀 테이블 스캔이 아닌 인덱스 스캔을 수행하며,
![image](https://github.com/user-attachments/assets/b374a684-926d-4f7b-8461-a06ad497505f)
평균적으로 약 `40ms` 의 속도로 약 `15배`의 성능 향상으로 원하는 데이터를 가져올 수 있었습니다.

또한, 해당 API 는 반복문으로 사용자의 반려동물 수만큼 쿼리를 수행해 데이터를 가져오는데, 이 문제도 `JOIN` 을 활용하여 한 번의 쿼리 요청으로 데이터들을 가져오도록 보완했습니다.

## 개선해야할 점
데이터가 거의 없어 크게 불편함을 느끼지 못한 이슈였지만, 데이터의 양이 많아졌을 경우를 미리 대비하여 데이터 조회 성능 최적화를 진행했습니다.
저희가 구현한 조회 쿼리들에 대해서도 모두 최적화를 진행해야하며, 조회 뿐만이 아니라 삽입/수정/삭제에 대해서도 고민할 필요가 있습니다.

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
