### PR TITLE
[feat/daengle-121] 결제시스템, Resilience4J를 활용한 서킷브레이커 패턴 적용

### DIFF
--- a/daengle-payment-api/build.gradle
+++ b/daengle-payment-api/build.gradle
@@ -49,6 +49,12 @@ dependencies {
 
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
+    implementation 'io.github.resilience4j:resilience4j-retry:2.0.2'
+    implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.0.2'
+    implementation 'io.github.resilience4j:resilience4j-timelimiter:2.0.2'
 }
 
 test {

--- a/daengle-payment-api/src/main/java/ddog/payment/presentation/PaymentController.java
+++ b/daengle-payment-api/src/main/java/ddog/payment/presentation/PaymentController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static ddog.auth.exception.common.CommonResponseEntity.success;
 
@@ -26,8 +27,9 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping("/validate")
-    public CommonResponseEntity<PaymentCallbackResp> validationPayment(@RequestBody PaymentCallbackReq paymentCallbackReq) {
-            return success(paymentService.validationPayment(paymentCallbackReq));
+    public CompletableFuture<CommonResponseEntity<PaymentCallbackResp>> validationPayment(@RequestBody PaymentCallbackReq paymentCallbackReq) {
+        return paymentService.validationPayment(paymentCallbackReq)
+                .thenApply(CommonResponseEntity::success); // 성공 응답 래핑
     }
 
     @PostMapping("/cancel/{reservationId}")


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 기존에는 CompletableFuture만으로 결제시스템의 외부 API(포트원)를 사용하는 기능에 타임아웃을 설정했습니다. 
    - 하지만 CompletableFuture은 타임 아웃 이후 작업에 대한 관리가 복잡하고 예외 처리 일관성이 부족합니다.
    - 무엇보다 Resilience4J는 서버의 장애 전파를 막기위해 많이 사용되며 서킷 브레이커 패턴을 쉽게 적용할 수 있는 라이브러리입니다.
    - Resilience4J는 서킷 브레이커(Circuit Breaker), 타임리미터(TimeLimiter), 재시도(Retry) 등 안정성을 높이는 여러 기능을 제공합니다.
    - 추후 확장성을 위해 해당 라이브러리를 추가합니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 결제 검증 시, PG사의 응답이 지연되거나 네트워크 문제로 인해 타임아웃이 발생할 수 있습니다. 
    - 이 경우, 사용자에게는 결제되지 않았다는 메시지가 표시되지만, 실제로 PG사는 결제를 처리했을 가능성도 존재합니다. 
    - 이를 처리하기 위한 유효한 방법은 결제 검증을 비동기적으로 처리하고, 타임아웃이 발생한 결제에 대해 후속 작업을 통해 정확한 상태를 확인하는 것입니다.
    - 이 후속작업을 어떤 자료구조(jobQ)에 영속할지, 처리는 누가(Consumer) 어떻게 할지 고민해보겠습니다. 

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : YES (Resilience4J)
