### PR TITLE
[feat/daengle-124] 모니터링을 위한 모듈별 Spring Actuator 및 Prometheus 의존성 추가

### DIFF
--- a/daengle-groomer-api/build.gradle
+++ b/daengle-groomer-api/build.gradle
@@ -24,4 +24,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    //prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/daengle-notification/build.gradle
+++ b/daengle-notification/build.gradle
@@ -23,5 +23,11 @@ dependencies {
     // Resilience4j
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
     implementation 'io.github.resilience4j:resilience4j-timelimiter'
+
+    //actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    //prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 

--- a/daengle-payment-api/build.gradle
+++ b/daengle-payment-api/build.gradle
@@ -55,6 +55,12 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-retry:2.0.2'
     implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.0.2'
     implementation 'io.github.resilience4j:resilience4j-timelimiter:2.0.2'
+
+    //actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    //prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 test {

--- a/daengle-user-api/build.gradle
+++ b/daengle-user-api/build.gradle
@@ -30,4 +30,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    //prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/daengle-vet-api/build.gradle
+++ b/daengle-vet-api/build.gradle
@@ -24,4 +24,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    //prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - api 별 Spring Actuator 의존성 추가
    - api 별 Prometheus 의존성 추가
    - api 별 `application.yml` Spring Actuator 설정
    - Prometheus - Grafana 연결

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

```yaml
    //actuator
    implementation 'org.springframework.boot:spring-boot-starter-actuator'

    //prometheus
    implementation 'io.micrometer:micrometer-registry-prometheus'
```
