### PR TITLE
[fix/daengle-127] 견적 관련 카운트 쿼리 로직 수정

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/CareEstimatePersist.java
@@ -41,4 +41,7 @@ public interface CareEstimatePersist {
     Optional<CareEstimate> findEstimateByUserIdAndPetId(Long userId, Long petId);
 
     Integer countEstimateByVetIdDistinctParentId(Long vetId);
+
+    List<CareEstimate> findByCareEstimateStatusBy(Long userId, EstimateStatus estimateStatus);
+
 }

--- a/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/estimate/port/GroomingEstimatePersist.java
@@ -39,4 +39,6 @@ public interface GroomingEstimatePersist {
 
     Integer countEstimateByGroomerIdDistinctParentId(Long groomerId);
 
+    List<GroomingEstimate> findByGroomingEstimateStatusBy(Long userId, EstimateStatus estimateStatus);
+
 }

--- a/daengle-groomer-api/src/main/java/ddog/groomer/presentation/estimate/EstimateController.java
+++ b/daengle-groomer-api/src/main/java/ddog/groomer/presentation/estimate/EstimateController.java
@@ -2,15 +2,12 @@ package ddog.groomer.presentation.estimate;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
-import ddog.domain.estimate.Estimate;
-import ddog.domain.notification.enums.NotifyType;
 import ddog.groomer.application.EstimateService;
 import ddog.groomer.presentation.estimate.dto.CreatePendingEstimateReq;
 import ddog.groomer.presentation.estimate.dto.EstimateDetail;
 import ddog.groomer.presentation.estimate.dto.EstimateInfo;
 import ddog.groomer.presentation.estimate.dto.EstimateResp;
 import ddog.notification.application.KakaoNotificationService;
-import ddog.notification.application.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +20,6 @@ import static ddog.auth.exception.common.CommonResponseEntity.success;
 public class EstimateController {
 
     private final EstimateService estimateService;
-    private final NotificationService notificationService;
     private final KakaoNotificationService kakaoNotificationService;
 
     private final Environment environment;
@@ -59,7 +55,6 @@ public class EstimateController {
     @PostMapping
     public CommonResponseEntity<EstimateResp> createEstimate(@RequestBody CreatePendingEstimateReq request, PayloadDto payloadDto) {
         EstimateInfo.EstimateUserInfo savedEstimate = estimateService.findByUserInfoByEstimateId(request.getId());
-        notificationService.sendNotificationToUser(savedEstimate.getUserId(), NotifyType.ESTIMATED, "미용사에게서 추가 소견 내용이 도착했어요!");
         kakaoNotificationService.sendOneTalk(savedEstimate.getUserNickname(), savedEstimate.getUserPhone(), environment.getProperty("templateId.ESTIMATED"));
         return success(estimateService.createPendingEstimate(request, payloadDto.getAccountId()));
     }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/CareEstimateRepository.java
@@ -129,5 +129,10 @@ public class CareEstimateRepository implements CareEstimatePersist {
     public Integer countEstimateByVetIdDistinctParentId(Long vetId) {
         return careEstimateJpaRepository.countDistinctParentIdsByVetAccountId(vetId);
     }
+
+    @Override
+    public List<CareEstimate> findByCareEstimateStatusBy(Long userId, EstimateStatus estimateStatus) {
+        return careEstimateJpaRepository.findCareEstimatesByVetIdAndStatus(userId, EstimateStatus.NEW).stream().map(CareEstimateJpaEntity::toModel).toList();
+    }
 }
 

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/adapter/GroomingEstimateRepository.java
@@ -110,4 +110,9 @@ public class GroomingEstimateRepository implements GroomingEstimatePersist {
     public Integer countEstimateByGroomerIdDistinctParentId(Long groomerId) {
         return groomingEstimateJpaRepository.countDistinctParentIdsByGroomerAccountId(groomerId);
     }
+
+    @Override
+    public List<GroomingEstimate> findByGroomingEstimateStatusBy(Long userId, EstimateStatus estimateStatus) {
+        return groomingEstimateJpaRepository.findAllByGroomerIdAndStatus(userId, estimateStatus).stream().map(GroomingEstimateJpaEntity::toModel).toList();
+    }
 }

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/CareEstimateJpaRepository.java
@@ -68,9 +68,9 @@ public interface CareEstimateJpaRepository extends JpaRepository<CareEstimateJpa
 
     Optional<CareEstimateJpaEntity> findCareEstimateJpaEntityByUserIdAndVetId(Long userId, Long vetId);
 
-    @Query("SELECT COUNT(c) " +
+    @Query("SELECT COUNT(DISTINCT c.parentId) " +
             "FROM CareEstimates c " +
-            "WHERE c.vetId = :vetAccountId AND c.parentId IS NULL")
+            "WHERE c.vetId = :vetAccountId")
     Integer countDistinctParentIdsByVetAccountId(@Param("vetAccountId") Long vetAccountId);
 
     Optional<CareEstimateJpaEntity> findCareEstimateJpaEntityByUserIdAndPetId(Long userId, Long petId);

--- a/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
+++ b/daengle-persistence-mysql/src/main/java/ddog/persistence/mysql/jpa/repository/GroomingEstimateJpaRepository.java
@@ -60,8 +60,8 @@ public interface GroomingEstimateJpaRepository extends JpaRepository<GroomingEst
 
     Optional<GroomingEstimateJpaEntity> findGroomingEstimateJpaEntityByPetIdAndGroomerId(Long petId, Long groomerId);
 
-    @Query("SELECT COUNT(c) " +
+    @Query("SELECT COUNT(DISTINCT c.parentId) " +
             "FROM GroomingEstimates c " +
-            "WHERE c.groomerId = :groomerAccountId AND c.parentId IS NULL")
+            "WHERE c.groomerId = :groomerAccountId")
     Integer countDistinctParentIdsByGroomerAccountId(@Param("groomerAccountId") Long groomerAccountId);
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/AccountInfoService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/AccountInfoService.java
@@ -1,6 +1,7 @@
 package ddog.user.application;
 
 import ddog.domain.estimate.CareEstimate;
+import ddog.domain.estimate.EstimateStatus;
 import ddog.domain.estimate.GroomingEstimate;
 import ddog.domain.estimate.port.CareEstimatePersist;
 import ddog.domain.estimate.port.GroomingEstimatePersist;
@@ -50,8 +51,8 @@ public class AccountInfoService {
         Page<CareReview> savedCareReview = careReviewPersist.findByReviewerId(accountId, Pageable.unpaged());
         Integer reviewCount = Math.toIntExact(savedCareReview.getTotalElements() + savedGroomingReview.getTotalElements());
 
-        List<GroomingEstimate> savedGroomingEstimate = groomingEstimatePersist.findMyEstimatesByUserId(accountId);
-        List<CareEstimate> savedCareEstimate = careEstimatePersist.findMyEstimatesByUserId(accountId);
+        List<GroomingEstimate> savedGroomingEstimate = groomingEstimatePersist.findByGroomingEstimateStatusBy(accountId, EstimateStatus.NEW);
+        List<CareEstimate> savedCareEstimate = careEstimatePersist.findByCareEstimateStatusBy(accountId, EstimateStatus.NEW);
         Integer estimateCount = savedCareEstimate.size() + savedGroomingEstimate.size();
 
         return MyProfileResp.builder()

--- a/daengle-user-api/src/main/java/ddog/user/application/DetailInfoService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/DetailInfoService.java
@@ -92,7 +92,7 @@ public class DetailInfoService {
                 .endTime(findBeautyShop.getEndTime())
                 .startTime(findBeautyShop.getStartTime())
                 .groomers(groomerSummaryInfos)
-                .imageUrlList(findBeautyShop.getImageUrlList())
+                .shopImage(findBeautyShop.getImageUrl())
                 .introduction(findBeautyShop.getIntroduction())
                 .closedDay(findBeautyShop.getClosedDays())
                 .shopNumber(findBeautyShop.getPhoneNumber())

--- a/daengle-user-api/src/main/java/ddog/user/presentation/detailInfo/dto/DetailResp.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/detailInfo/dto/DetailResp.java
@@ -39,7 +39,7 @@ public class DetailResp {
         private Long shopId;
         private String shopName;
         private String shopAddress;
-        private List<String> imageUrlList;
+        private String shopImage;
         private List<GroomerSummaryInfo> groomers;
         private LocalTime startTime;
         private LocalTime endTime;

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/CareReviewController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/CareReviewController.java
@@ -2,14 +2,9 @@ package ddog.user.presentation.review;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
-import ddog.domain.notification.enums.NotifyType;
-import ddog.domain.payment.port.ReservationPersist;
 import ddog.notification.application.KakaoNotificationService;
-import ddog.notification.application.NotificationService;
-import ddog.user.application.EstimateService;
 import ddog.user.application.ReservationService;
 import ddog.user.presentation.reservation.dto.ReservationInfo;
-import ddog.user.presentation.reservation.dto.ReservationSummary;
 import ddog.user.presentation.review.dto.response.CareReviewListResp;
 import ddog.user.presentation.review.dto.request.UpdateCareReviewInfo;
 import ddog.user.presentation.review.dto.request.PostCareReviewInfo;
@@ -30,7 +25,6 @@ public class CareReviewController {
     private final CareReviewService careReviewService;
     private final ReservationService reservationService;
     private final KakaoNotificationService kakaoNotificationService;
-    private final NotificationService notificationService;
     private final Environment environment;
 
     @GetMapping("/care/review/{reviewId}")
@@ -42,7 +36,6 @@ public class CareReviewController {
     public CommonResponseEntity<ReviewResp> postReview(@RequestBody PostCareReviewInfo postCareReviewInfo) {
         ReservationInfo.ReservationUsersInfo findReservationInfo= reservationService.getCareUserAndPartnerDetail(postCareReviewInfo.getReservationId());
         kakaoNotificationService.sendOneTalk(findReservationInfo.getPartnerName(), findReservationInfo.getPartnerPhone(), environment.getProperty("templateId.REVIEWED"));
-        notificationService.sendNotificationToUser(findReservationInfo.getPartnerId(), NotifyType.REVIEWED, findReservationInfo.getUserName()+"님의 리뷰가 등록됐어요!");
         return success(careReviewService.postReview(postCareReviewInfo));
     }
 

--- a/daengle-user-api/src/main/java/ddog/user/presentation/review/GroomingReviewController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/review/GroomingReviewController.java
@@ -27,7 +27,6 @@ public class GroomingReviewController {
     private final GroomingReviewService groomingReviewService;
     private final ReservationService reservationService;
     private final KakaoNotificationService kakaoNotificationService;
-    private final NotificationService notificationService;
     private final Environment environment;
 
     @GetMapping("/grooming/review/{reviewId}")
@@ -39,7 +38,6 @@ public class GroomingReviewController {
     public CommonResponseEntity<ReviewResp> postReview(@RequestBody PostGroomingReviewInfo postGroomingReviewInfo) {
         ReservationInfo.ReservationUsersInfo findReservationInfo = reservationService.getGroomingUserAndPartnerDetail(postGroomingReviewInfo.getReservationId());
         kakaoNotificationService.sendOneTalk(findReservationInfo.getUserName(), findReservationInfo.getPartnerPhone(), environment.getProperty("templateId.REVIEWED"));
-        notificationService.sendNotificationToUser(findReservationInfo.getPartnerId(), NotifyType.REVIEWED, findReservationInfo.getUserName()+"님의 리뷰가 등록됐어요!");
         return success(groomingReviewService.postReview(postGroomingReviewInfo));
     }
 

--- a/daengle-vet-api/src/main/java/ddog/vet/presentation/estimate/EstimateController.java
+++ b/daengle-vet-api/src/main/java/ddog/vet/presentation/estimate/EstimateController.java
@@ -2,9 +2,7 @@ package ddog.vet.presentation.estimate;
 
 import ddog.auth.dto.PayloadDto;
 import ddog.auth.exception.common.CommonResponseEntity;
-import ddog.domain.notification.enums.NotifyType;
 import ddog.notification.application.KakaoNotificationService;
-import ddog.notification.application.NotificationService;
 import ddog.vet.application.EstimateService;
 import ddog.vet.presentation.estimate.dto.CreatePendingEstimateReq;
 import ddog.vet.presentation.estimate.dto.EstimateDetail;
@@ -22,7 +20,6 @@ import static ddog.auth.exception.common.CommonResponseEntity.success;
 public class EstimateController {
 
     private final EstimateService estimateService;
-    private final NotificationService notificationService;
     private final KakaoNotificationService kakaoNotificationService;
 
     private final Environment environment;
@@ -57,7 +54,6 @@ public class EstimateController {
     @PostMapping
     public CommonResponseEntity<EstimateResp> createEstimate(@RequestBody CreatePendingEstimateReq request, PayloadDto payloadDto) {
         EstimateInfo.EstimateUserInfo savedEstimate = estimateService.findByUserInfoByEstimateId(request.getId());
-        notificationService.sendNotificationToUser(savedEstimate.getUserId(), NotifyType.ESTIMATED, "미용사에게서 추가 소견 내용이 도착했어요!");
         kakaoNotificationService.sendOneTalk(savedEstimate.getUserNickname(), savedEstimate.getUserPhone(), environment.getProperty("templateId.ESTIMATED"));
         return success(estimateService.createPendingEstimate(request, payloadDto.getAccountId()));
     }


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : X
    - [Notion-API] : X

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 견적 관련 카운트 쿼리 로직 수정 피드백반영하여 진행했습니다
    - 푸시 알림 제외
    - 미용샵 상세 정보 이미지 배열 -> 하나의 이미지로 변경

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    -  X

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부

    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
