### PR TITLE
[refactoring/daengle-130] 기존 검색 API 조회 성능 개선 및 JPA N+1 문제 해결

### DIFF
--- a/daengle-domain/src/main/java/ddog/domain/groomer/dto/SearchGroomerResultDto.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/dto/SearchGroomerResultDto.java
@@ -1,0 +1,36 @@
+package ddog.domain.groomer.dto;
+
+import ddog.domain.groomer.enums.GroomingBadge;
+
+import java.util.List;
+
+public class SearchGroomerResultDto {
+
+    private final Long accountId;
+    private final String name;
+    private final String imageUrl;
+    private final List<GroomingBadge> badges;
+
+    public SearchGroomerResultDto(Long accountId, String name, String imageUrl, List<GroomingBadge> badges) {
+        this.accountId = accountId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.badges = badges;
+    }
+
+    public Long getAccountId() {
+        return accountId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public List<GroomingBadge> getBadges() {
+        return badges;
+    }
+}

--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
@@ -5,6 +5,7 @@ import ddog.domain.groomer.enums.GroomingBadge;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroomerPersist {
@@ -15,7 +16,7 @@ public interface GroomerPersist {
 
     Optional<Groomer> findByGroomerId(Long groomerId);
 
-    Page<Groomer> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable);
+    List<Groomer> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable);
 
     void deleteByAccountId(Long accountId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
@@ -2,7 +2,6 @@ package ddog.domain.groomer.port;
 
 import ddog.domain.groomer.Groomer;
 import ddog.domain.groomer.enums.GroomingBadge;
-import ddog.domain.groomer.enums.GroomingKeyword;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -16,6 +15,7 @@ public interface GroomerPersist {
 
     Optional<Groomer> findByGroomerId(Long groomerId);
 
-    Page<Groomer> findGroomerByKeyword(String address, String keyword, GroomingBadge tag, Pageable pageable);
+    Page<Groomer> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable);
+
     void deleteByAccountId(Long accountId);
 }

--- a/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
+++ b/daengle-domain/src/main/java/ddog/domain/groomer/port/GroomerPersist.java
@@ -1,6 +1,7 @@
 package ddog.domain.groomer.port;
 
 import ddog.domain.groomer.Groomer;
+import ddog.domain.groomer.dto.SearchGroomerResultDto;
 import ddog.domain.groomer.enums.GroomingBadge;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +17,7 @@ public interface GroomerPersist {
 
     Optional<Groomer> findByGroomerId(Long groomerId);
 
-    List<Groomer> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable);
+    List<SearchGroomerResultDto> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable);
 
     void deleteByAccountId(Long accountId);
 }

--- a/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/adapter/GroomerRepository.java
+++ b/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/adapter/GroomerRepository.java
@@ -36,8 +36,9 @@ public class GroomerRepository implements GroomerPersist {
     }
 
     @Override
-    public Page<Groomer> findGroomerByKeyword(String address, String keyword, GroomingBadge tag, Pageable pageable) {
-        return groomerJpaRepository.findAllGroomersBy(address, keyword, tag, pageable).map(GroomerJpaEntity::toModel);
+    public Page<Groomer> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable) {
+        return groomerJpaRepository.findGroomersByKeywords(address, name, badge, pageable)
+                .map(GroomerJpaEntity::toModel);
     }
 
     @Override

--- a/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/adapter/GroomerRepository.java
+++ b/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/adapter/GroomerRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -36,9 +37,13 @@ public class GroomerRepository implements GroomerPersist {
     }
 
     @Override
-    public Page<Groomer> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable) {
-        return groomerJpaRepository.findGroomersByKeywords(address, name, badge, pageable)
-                .map(GroomerJpaEntity::toModel);
+    public List<Groomer> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable) {
+        Page<Long> pagedGroomerIds = groomerJpaRepository.findPagedGroomerIds(address, name, badge, pageable);
+        List<Long> groomerIds = pagedGroomerIds.getContent();
+
+        return groomerJpaRepository.findGroomersWithDetails(groomerIds)
+                .stream().map(GroomerJpaEntity::toModel)
+                .toList();
     }
 
     @Override

--- a/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/adapter/GroomerRepository.java
+++ b/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/adapter/GroomerRepository.java
@@ -1,6 +1,7 @@
 package ddog.persistence.rdb.adapter;
 
 import ddog.domain.groomer.Groomer;
+import ddog.domain.groomer.dto.SearchGroomerResultDto;
 import ddog.domain.groomer.enums.GroomingBadge;
 import ddog.persistence.rdb.jpa.entity.GroomerJpaEntity;
 import ddog.persistence.rdb.jpa.repository.GroomerJpaRepository;
@@ -10,8 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -37,13 +37,32 @@ public class GroomerRepository implements GroomerPersist {
     }
 
     @Override
-    public List<Groomer> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable) {
-        Page<Long> pagedGroomerIds = groomerJpaRepository.findPagedGroomerIds(address, name, badge, pageable);
-        List<Long> groomerIds = pagedGroomerIds.getContent();
+    public List<SearchGroomerResultDto> findGroomersByKeywords(String address, String name, GroomingBadge badge, Pageable pageable) {
+        List<Long> groomerIds = groomerJpaRepository.findPagedGroomerIds(address, name, badge, pageable).getContent();
+        List<Object[]> groomersWithDetails = groomerJpaRepository.findGroomersWithDetails(groomerIds);
 
-        return groomerJpaRepository.findGroomersWithDetails(groomerIds)
-                .stream().map(GroomerJpaEntity::toModel)
-                .toList();
+        Map<Long, SearchGroomerResultDto> dtoMap = new HashMap<>();
+
+        for (Object[] groomerWithDetail : groomersWithDetails) {
+            Long accountId = ((Number) groomerWithDetail[0]).longValue();
+            String groomerName = (String) groomerWithDetail[1];
+            String imageUrl = (String) groomerWithDetail[2];
+
+            if (!dtoMap.containsKey(accountId)){
+                dtoMap.put(accountId, new SearchGroomerResultDto(accountId, groomerName, imageUrl, new ArrayList<>()));
+            }
+
+            if (groomerWithDetail[3] == null) {
+                continue;
+            }
+
+            GroomingBadge groomingBadge = GroomingBadge.valueOf((String) groomerWithDetail[3]);
+            List<GroomingBadge> groomingBadges = dtoMap.get(accountId).getBadges();
+            groomingBadges.add(groomingBadge);
+            dtoMap.put(accountId, new SearchGroomerResultDto(accountId, groomerName, imageUrl, groomingBadges));
+        }
+
+        return new ArrayList<>(dtoMap.values());
     }
 
     @Override

--- a/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/jpa/repository/GroomerJpaRepository.java
+++ b/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/jpa/repository/GroomerJpaRepository.java
@@ -19,11 +19,11 @@ public interface GroomerJpaRepository extends JpaRepository<GroomerJpaEntity, Lo
     @Query("SELECT v FROM Groomers v " +
             "LEFT JOIN v.keywords k " +
             "WHERE (:address IS NULL OR :address = '' OR v.address LIKE CONCAT('%', :address, '%')) " +
-            "AND (:keyword IS NULL OR :keyword = '' OR v.name LIKE CONCAT('%', :keyword, '%')) " +
+            "AND (:name IS NULL OR :name = '' OR v.name LIKE CONCAT('%', :name, '%')) " +
             "AND (:badge IS NULL OR :badge = '' OR :badge MEMBER OF v.badges)")
-    Page<GroomerJpaEntity> findAllGroomersBy(
+    Page<GroomerJpaEntity> findGroomersByKeywords(
             @Param("address") String address,
-            @Param("keyword") String keyword,
+            @Param("name") String name,
             @Param("badge") GroomingBadge badge,
             Pageable pageable
     );

--- a/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/jpa/repository/GroomerJpaRepository.java
+++ b/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/jpa/repository/GroomerJpaRepository.java
@@ -16,11 +16,10 @@ public interface GroomerJpaRepository extends JpaRepository<GroomerJpaEntity, Lo
 
     Optional<GroomerJpaEntity> findByGroomerId(Long groomerId);
 
-    @Query("SELECT v FROM Groomers v " +
-            "LEFT JOIN v.keywords k " +
-            "WHERE (:address IS NULL OR :address = '' OR v.address LIKE CONCAT('%', :address, '%')) " +
-            "AND (:name IS NULL OR :name = '' OR v.name LIKE CONCAT('%', :name, '%')) " +
-            "AND (:badge IS NULL OR :badge = '' OR :badge MEMBER OF v.badges)")
+    @Query("SELECT g FROM Groomers g " +
+            "WHERE (:address IS NULL OR :address = '' OR g.address LIKE CONCAT('%', :address, '%')) " +
+            "AND (:name IS NULL OR :name = '' OR g.name LIKE CONCAT('%', :name, '%')) " +
+            "AND (:badge IS NULL OR :badge MEMBER OF g.badges)")
     Page<GroomerJpaEntity> findGroomersByKeywords(
             @Param("address") String address,
             @Param("name") String name,

--- a/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/jpa/repository/GroomerJpaRepository.java
+++ b/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/jpa/repository/GroomerJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroomerJpaRepository extends JpaRepository<GroomerJpaEntity, Long> {
@@ -16,15 +17,21 @@ public interface GroomerJpaRepository extends JpaRepository<GroomerJpaEntity, Lo
 
     Optional<GroomerJpaEntity> findByGroomerId(Long groomerId);
 
-    @Query("SELECT g FROM Groomers g " +
+    @Query("SELECT g.groomerId FROM Groomers g " +
             "WHERE (:address IS NULL OR :address = '' OR g.address LIKE CONCAT('%', :address, '%')) " +
             "AND (:name IS NULL OR :name = '' OR g.name LIKE CONCAT('%', :name, '%')) " +
             "AND (:badge IS NULL OR :badge MEMBER OF g.badges)")
-    Page<GroomerJpaEntity> findGroomersByKeywords(
+    Page<Long> findPagedGroomerIds(
             @Param("address") String address,
             @Param("name") String name,
             @Param("badge") GroomingBadge badge,
             Pageable pageable
     );
+
+    @Query("SELECT DISTINCT g FROM Groomers g " +
+            "LEFT JOIN FETCH g.badges b " +
+            "WHERE g.groomerId IN :ids")
+    List<GroomerJpaEntity> findGroomersWithDetails(@Param("ids") List<Long> ids);
+
     void deleteByAccountId(Long accountId);
 }

--- a/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/jpa/repository/GroomerJpaRepository.java
+++ b/daengle-persistence-rdb/src/main/java/ddog/persistence/rdb/jpa/repository/GroomerJpaRepository.java
@@ -28,10 +28,12 @@ public interface GroomerJpaRepository extends JpaRepository<GroomerJpaEntity, Lo
             Pageable pageable
     );
 
-    @Query("SELECT DISTINCT g FROM Groomers g " +
-            "LEFT JOIN FETCH g.badges b " +
-            "WHERE g.groomerId IN :ids")
-    List<GroomerJpaEntity> findGroomersWithDetails(@Param("ids") List<Long> ids);
+    @Query(value =
+            "SELECT g.account_id, g.name, g.image_url, b.grooming_badge " +
+            "FROM groomers g " +
+            "LEFT JOIN grooming_badges b ON g.groomer_id = b.groomer_id " +
+            "WHERE g.groomer_id IN :ids", nativeQuery = true)
+    List<Object[]> findGroomersWithDetails(@Param("ids") List<Long> ids);
 
     void deleteByAccountId(Long accountId);
 }

--- a/daengle-user-api/src/main/java/ddog/user/application/SearchService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/SearchService.java
@@ -6,7 +6,7 @@ import ddog.domain.groomer.port.GroomerPersist;
 import ddog.domain.vet.Vet;
 import ddog.domain.vet.enums.CareBadge;
 import ddog.domain.vet.port.VetPersist;
-import ddog.user.presentation.search.dto.SearchGroomingResultByKeyword;
+import ddog.user.presentation.search.dto.GroomerResult;
 import ddog.user.presentation.search.dto.SearchVetResultByKeyword;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,12 +22,12 @@ public class SearchService {
     private final GroomerPersist groomerPersist;
     private final VetPersist vetPersist;
 
-    public SearchGroomingResultByKeyword getGroomerResultBySearch(int page, int size, String address, String keyword, GroomingBadge badge) {
+    public GroomerResult findGroomerResultsBySearch(int page, int size, String address, String name, GroomingBadge badge) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Groomer> groomerPage = groomerPersist.findGroomerByKeyword(address, keyword, badge, pageable);
+        Page<Groomer> groomerPage = groomerPersist.findGroomersByKeywords(address, name, badge, pageable);
 
-        List<SearchGroomingResultByKeyword.ResultList> resultList = groomerPage.stream()
-                .map(groomer -> SearchGroomingResultByKeyword.ResultList.builder()
+        List<GroomerResult.Results> results = groomerPage.stream()
+                .map(groomer -> GroomerResult.Results.builder()
                         .partnerId(groomer.getAccountId())
                         .partnerName(groomer.getName())
                         .partnerImage(groomer.getImageUrl())
@@ -35,8 +35,8 @@ public class SearchService {
                         .build())
                 .toList();
 
-        return SearchGroomingResultByKeyword.builder()
-                .result(resultList)
+        return GroomerResult.builder()
+                .result(results)
                 .page(groomerPage.getNumber())
                 .size(groomerPage.getSize())
                 .totalElements(groomerPage.getTotalElements())

--- a/daengle-user-api/src/main/java/ddog/user/application/SearchService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/SearchService.java
@@ -24,7 +24,7 @@ public class SearchService {
 
     public GroomerResult findGroomerResultsBySearch(int page, int size, String address, String name, GroomingBadge badge) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Groomer> groomerPage = groomerPersist.findGroomersByKeywords(address, name, badge, pageable);
+        List<Groomer> groomerPage = groomerPersist.findGroomersByKeywords(address, name, badge, pageable);
 
         List<GroomerResult.Results> results = groomerPage.stream()
                 .map(groomer -> GroomerResult.Results.builder()
@@ -37,12 +37,10 @@ public class SearchService {
 
         return GroomerResult.builder()
                 .result(results)
-                .page(groomerPage.getNumber())
-                .size(groomerPage.getSize())
-                .totalElements(groomerPage.getTotalElements())
                 .build();
 
     }
+
     public SearchVetResultByKeyword getVetResultBySearch(int page, int size, String address, String keyword, CareBadge badge) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Vet> vetPage = vetPersist.findVetByKeyword(address, keyword, badge, pageable);

--- a/daengle-user-api/src/main/java/ddog/user/application/SearchService.java
+++ b/daengle-user-api/src/main/java/ddog/user/application/SearchService.java
@@ -1,6 +1,7 @@
 package ddog.user.application;
 
 import ddog.domain.groomer.Groomer;
+import ddog.domain.groomer.dto.SearchGroomerResultDto;
 import ddog.domain.groomer.enums.GroomingBadge;
 import ddog.domain.groomer.port.GroomerPersist;
 import ddog.domain.vet.Vet;
@@ -24,7 +25,7 @@ public class SearchService {
 
     public GroomerResult findGroomerResultsBySearch(int page, int size, String address, String name, GroomingBadge badge) {
         Pageable pageable = PageRequest.of(page, size);
-        List<Groomer> groomerPage = groomerPersist.findGroomersByKeywords(address, name, badge, pageable);
+        List<SearchGroomerResultDto> groomerPage = groomerPersist.findGroomersByKeywords(address, name, badge, pageable);
 
         List<GroomerResult.Results> results = groomerPage.stream()
                 .map(groomer -> GroomerResult.Results.builder()
@@ -38,7 +39,6 @@ public class SearchService {
         return GroomerResult.builder()
                 .result(results)
                 .build();
-
     }
 
     public SearchVetResultByKeyword getVetResultBySearch(int page, int size, String address, String keyword, CareBadge badge) {

--- a/daengle-user-api/src/main/java/ddog/user/presentation/search/SearchController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/search/SearchController.java
@@ -20,6 +20,7 @@ import static ddog.auth.exception.common.CommonResponseEntity.success;
 public class SearchController {
 
     private final SearchService searchService;
+
     @GetMapping("/groomer")
     public CommonResponseEntity<GroomerResult> findGroomerSearchList(
             @RequestParam(defaultValue = "0") int page,

--- a/daengle-user-api/src/main/java/ddog/user/presentation/search/SearchController.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/search/SearchController.java
@@ -2,11 +2,9 @@ package ddog.user.presentation.search;
 
 import ddog.auth.exception.common.CommonResponseEntity;
 import ddog.domain.groomer.enums.GroomingBadge;
-import ddog.domain.groomer.enums.GroomingKeyword;
 import ddog.domain.vet.enums.CareBadge;
-import ddog.domain.vet.enums.CareKeyword;
 import ddog.user.application.SearchService;
-import ddog.user.presentation.search.dto.SearchGroomingResultByKeyword;
+import ddog.user.presentation.search.dto.GroomerResult;
 import ddog.user.presentation.search.dto.SearchVetResultByKeyword;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,14 +21,14 @@ public class SearchController {
 
     private final SearchService searchService;
     @GetMapping("/groomer")
-    public CommonResponseEntity<SearchGroomingResultByKeyword> findGroomerSearchList(
+    public CommonResponseEntity<GroomerResult> findGroomerSearchList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "6") int size,
             @RequestParam(required = false) String address,
-            @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) GroomingBadge tag
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) GroomingBadge badge
     ) {
-        return success(searchService.getGroomerResultBySearch(page, size, address, keyword, tag));
+        return success(searchService.findGroomerResultsBySearch(page, size, address, name, badge));
     }
 
     @GetMapping("/vet")

--- a/daengle-user-api/src/main/java/ddog/user/presentation/search/dto/GroomerResult.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/search/dto/GroomerResult.java
@@ -9,9 +9,6 @@ import java.util.List;
 @Getter
 @Builder
 public class GroomerResult {
-    private int page;
-    private int size;
-    private long totalElements;
 
     List<Results> result;
 

--- a/daengle-user-api/src/main/java/ddog/user/presentation/search/dto/GroomerResult.java
+++ b/daengle-user-api/src/main/java/ddog/user/presentation/search/dto/GroomerResult.java
@@ -1,7 +1,6 @@
 package ddog.user.presentation.search.dto;
 
 import ddog.domain.groomer.enums.GroomingBadge;
-import ddog.domain.groomer.enums.GroomingKeyword;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,16 +8,16 @@ import java.util.List;
 
 @Getter
 @Builder
-public class SearchGroomingResultByKeyword {
+public class GroomerResult {
     private int page;
     private int size;
     private long totalElements;
 
-    List<ResultList> result;
+    List<Results> result;
 
     @Getter
     @Builder
-    public static class ResultList {
+    public static class Results {
         public Long partnerId;
         public String partnerName;
         public String partnerImage;


### PR DESCRIPTION
## 📝&nbsp;&nbsp;관련 문서 레퍼런스
- https://tecoble.techcourse.co.kr/post/2021-07-26-jpa-pageable/

## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?
- 미용사 및 병원 검색 API에서 발생하는 N+1 문제 해결
- 검색 결과에 실제로 필요한 데이터만 로드하는 최적화 구현
- 페이징 처리와 함께 효율적인 데이터 로드를 위한 단계적 쿼리 방식 도입
- Native Query를 활용한 실제 UI에 필요한 데이터만 조회하는 방식 구현

## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점
검색 API에서 미용사 및 병원 정보를 조회할 때 1차 쿼리 후 각 엔티티별로 연관 관계(뱃지, 라이센스 등)에 접근하며 발생하는 N+1 문제를 발견했습니다. 이 문제는 검색 결과 엔티티가 많아질수록 쿼리 수가 증가하여 성능 저하를 야기했습니다.

이 문제를 해결하기 위해 다음과 같은 접근 방식을 도입했습니다

1. **단계적 데이터 로드 방식**: 페이징 처리된 ID 목록을 먼저 조회한 후, 실제 필요한 데이터만 추가 쿼리로 로드하는 2단계 조회 방식 구현
   ```java
   @Query("SELECT g.id FROM Groomers g " + 
          "WHERE (:address IS NULL OR :address = '' OR g.address LIKE CONCAT('%', :address, '%')) " + 
          // ... 조건문 ...
          )
   Page<Long> findPagedGroomerIds(...);
   ```

2. **Native Query를 활용한 필요 데이터만 조회**: 엔티티 전체가 아닌 검색 결과에에 필요한 데이터(계정ID, 이름, 이미지URL, 뱃지)만 조회
   ```java
   @Query(value =
        "SELECT g.account_id, g.name, g.image_url, b.grooming_badge " +
        "FROM groomers g " +
        "LEFT JOIN grooming_badges b ON g.groomer_id = b.groomer_id " +
        "WHERE g.groomer_id IN :ids", nativeQuery = true)
   List<Object[]> findGroomersWithDetails(@Param("ids") List<Long> ids);
   ```

3. **데이터 매핑 로직 개선**: 조회 결과를 효율적으로 DTO로 변환하는 로직 구현
   ```java
   Map<Long, SearchGroomerResultDto> dtoMap = new HashMap<>();
   // 동일한 미용사 ID를 가진 결과를 그룹화하여 뱃지 리스트 구성
   ```

이를 통해 기존에는 검색 결과 6개 조회시 최소 13개의 쿼리가 발생하던 문제가 단 2개의 쿼리로 해결되었습니다.

예상되는 문제점으로는:
1. Native Query 사용으로 DB 변경 시 쿼리 수정이 필요할 수 있음
2. 데이터 매핑 로직이 다소 복잡해져 유지보수에 주의가 필요함
3. 검색 결과에 추가 정보가 필요한 경우 쿼리와 매핑 로직을 함께 수정해야 함

**자세한 내용은 아래 블로그에 정리했습니다 !**
[[미용사 및 병원 검색 API의 N+1 문제 해결](https://hyodeng.tistory.com/entry/%EB%AF%B8%EC%9A%A9%EC%82%AC-%EB%B0%8F-%EB%B3%91%EC%9B%90-%EA%B2%80%EC%83%89-API%EC%9D%98-N+1-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)](https://hyodeng.tistory.com/entry/미용사-및-병원-검색-API의-N+1-문제-해결)

## 💾&nbsp;&nbsp;RDB 변경사항 여부
- [업데이트] : No

## 📚&nbsp;&nbsp;추가된 라이브러리
- [추가] : No